### PR TITLE
Fixed Install Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To install you can type this commands in the terminal:
 ```shell
 git clone https://github.com/TheDarkBug/uwufetch.git
 cd uwufetch
-make install
+make
 ```
 
 To uninstall (this will also remove the repository folder):


### PR DESCRIPTION
make runs the target all, which builds it and then copies it, while currently you only get an error because the compiled file doesn't exist