### PR TITLE
nyandroid icon + updated README + standard GPL 3.0 boilerplate gobbledygook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 # UwUFetch
 
-A meme system info tool for Linux, based on nyan/UwU trend on r/linuxmasterrace.
+A meme system info tool for (almost) all your Linux/Unix-based systems, based on nyan/UwU trend on r/linuxmasterrace.
 
 ## Currently supported distros
 
-Nyarch Linuwu, Nyartix Linuwu, Debinyan, Fedowa, GentOwO, Myanjawo.
+Nyarch Linuwu, Nyartix Linuwu, Debinyan, Fedowa, GentOwO, Myanjawo, and UwUntu; Plus Nyandroid; and FweeBSD, and OwOpenBSD.
 
 ## Building and installation
 
 ##### Via package manager
 
-Right now the package is only available on the [AUR](https://aur.archlinux.org/packages/uwufetch-git/).
+Right now, the package is only available on the [AUR](https://aur.archlinux.org/packages/uwufetch-git/).
 
-##### Via git clone
+##### Via source
 
-To install you can type this commands in the terminal:
+To install UwUfetch from the source, type these commands in the terminal:
 
 ```shell
 git clone https://github.com/TheDarkBug/uwufetch.git

--- a/uwufetch.c
+++ b/uwufetch.c
@@ -1,3 +1,18 @@
+/*
+ *  UwUfetch is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <dirent.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -243,7 +258,11 @@ void print_ascii() {	// prints logo (as ascii art) of the given system. distribu
 				" %sC_/     %sO\n\n\n", PINK, LPINK, PINK, LPINK, PINK, LPINK);
 	} else if (strcmp(version_name, "android") == 0) {	// android at the end because it could be not considered as an actual distribution of gnu/linux
 		sprintf(version_name, "%s", "Nyandroid");
-		printf(	"\n\n\nascii icon\n  nedds to be\n     added\n\n\n\n\n");
+		printf(	"%s \n\\ _------_ /\n"
+			" /          \\\n"
+			"| %s~ %s> w < %s~  %s|\n"
+			" ------------\n", GREEN, RED, GREEN, RED, GREEN);
+
 	}
 
 	// BSD


### PR DESCRIPTION
"If I may so interject to this discussion, what you are so erroneously referring to as 'GNU/Linux' could more accurately be described as GNU/Linux/X+, depending on the software that the user in question is running. What you have to remember is that, while GNU has made extensive contributions to the family of operating systems that happen to use the Linux kernel, other contributions have been made by people outside of the GNU project, and have put just as much time into developing tools for a free operating system as the GNU project, and the contributors to the Linux kernel have. I should state first and foremost that many GNU/Linux/X+ operating systems do not use the Xorg window system (commonly shortened to simply X). However, because of the popularity that the Xorg window system has, I believe it is appropriate for it to be included in the conventional naming scheme. That said, any systems that run an alternate window system, lets use Wayland, for an example, should, obviously, be referred to as GNU/Linux/Wayland+. Now, that plus at the end is used to refer to the rest of the programs/tools/utilities/software on the system that falls out of the umbrella of the GNU project, the Linux kernel, and Xorg window system. This can include desktop environments, window managers, bootloaders, init systems, userlands, office tools, terminal emulators, core utilities, etc. All of these are necessary for a stable, usable free operating system, and when a user of a given free operating system distribution refers to their 'daily driver', - that is to say the free operating system distribution they use on a regular basis - they should have the moral consciousness to mention as much of the contributors and tools of the free operating system distribution they use, as not doing so weakens the sense of community of the free software movement, and, as a direct result, makes proprietary software developers stronger. However, for the sake of convenience, it is acceptable to use a shortened version (i.e, GNU/Linux/X+) of the systems name in certain circumstances, although a user of a free software operating system should, whenever possible, use the full name of the free software operating system they use. I personally have been using a Apcupsd/BusyBox/Clang/Das U-Boot/envsys/Fish/GNU/Gentoo/Htop/Iperf/Java/KDE/Kitty/LibreOffice/Linux/Mozilla/Nitrogen/OpenBox/OpenRC/Pidgin/PulseAudio/qBitTorrent/Rsync/Shadowsocks/Tor/UClibc/Vim/VLC/Wine/Wireshark/X/Zeek/Zsh system, which I love, and adore dearly, and have, obviously, used to compose this message on. I hope you understand my reasoning, and follow my example."