### PR TITLE
Remove GPU name truncation

### DIFF
--- a/uwufetch.c
+++ b/uwufetch.c
@@ -215,13 +215,6 @@ void get_info() {	// get all necessary info
 		while (fgets(line, sizeof(line), gpu)) if (sscanf(line, "%[^\n]", gpu_model[0])) break;
 	}
 	fclose(gpu);
-	
-	//	format the strings a bit
-	for(int i = 0; i < gpun; i++) {
-		for (int j = 42; j < 256; j++) {	//max gpu_name length
-			gpu_model[i][j] = '\0';
-		}
-	}
 
 	pkgs = pkgman();
 }


### PR DESCRIPTION
This PR removes the artificial 43 char limit for GPU names.

Current version: Ellesmere [Radeon RX 470/480/570/570X/580/
New version: Ellesmere [Radeon RX 470/480/570/570X/580/580X/590]

![preview](https://user-images.githubusercontent.com/30622888/111813611-b459d900-88d9-11eb-93dc-62f3a07373f7.png)
