### PR TITLE
gpu: forced LANG environement variable to en_US before running lshw

### DIFF
--- a/uwufetch.c
+++ b/uwufetch.c
@@ -205,6 +205,7 @@ void get_info() {	// get all necessary info
 
 	// gpu
 	int gpun = 0;	//	number of the gpu that the program is searching for to put in the array
+	setenv("LANG", "en_US", 1); // force language to english
 	FILE *gpu;
 	gpu = popen("lshw -class display 2> /dev/null", "r");
 


### PR DESCRIPTION
Before, as my system is configured with LANG=fr_FR
so, lshw would output in french, and the program
couldn't find the right strings in the output,
and so, my GPU wasn't properly detected.

There may be other instances of similar issues
in the code, but for now, everything shows up
correctly for me.