### PR TITLE
Zypper support, OpenSUSE icon mod, README changes, and APT comeback.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,11 @@
 A meme system info tool for (almost) all your Linux/Unix-based systems, based on nyan/UwU trend on r/linuxmasterrace.
 
 ## Currently supported distros
+#### Full support (Both Ascii art + images are provided for the given distribution)
+Nyalpine, Nyarch Linuwu, Nyartix Linuwu, Debinyan, Fedowa, GentOwO, Miwint, Myanjawo, OwOpenSUSE, Pop OwOs, RaspNyan, UwUntu, and OwOid; Plus Nyandroid.
 
-Nyalpine, Nyarch Linuwu, Nyartix Linuwu, Debinyan, Fedowa, GentOwO, Miwint, Myanjawo, Pop OwOs, RaspNyan, UwUntu, and OwOid; Plus Nyandroid; FweeBSD, and OwOpenBSD.
+#### Partial support (Either no Ascii art, or no image is provided)
+endeavOwO, KDE NeOwOn, nixOwOs, Swackwawe, sOwOlus; Plus FweeBSD, and OwOpenBSD
 
 ## Building and installation
 

--- a/uwufetch.c
+++ b/uwufetch.c
@@ -108,7 +108,7 @@ int pkgman() { // this is just a function that returns the total of installed pa
 		{ "nix-store -q --requisites /run/current-sys_vartem/sw 2> /dev/null | wc -l",	"(nix)"      },
 		{ "pacman -Qq 2> /dev/null | wc -l",											"(pacman)"   },
 		{ "rpm -qa --last 2> /dev/null | wc -l",										"(rpm)"      },
-		{ "xbps-query -l 2> /dev/null | wc -l",											"(xbps)"     }
+		{ "xbps-query -l 2> /dev/null | wc -l",											"(xbps)"     },
 		{ "zypper se --installed-only 2> /dev/null | wc -l",							"(zypper)"   }
 	};
 

--- a/uwufetch.c
+++ b/uwufetch.c
@@ -99,6 +99,7 @@ int pkgman() { // this is just a function that returns the total of installed pa
 	};
 
 	struct package_manager pkgmans[] = {
+		{ "apt list --installed 2> /dev/null | wc -l",									"(apt)"      },
 		{ "apk info 2> /dev/null | wc -l",												"(apk)"      },
 		{ "dnf list installed 2> /dev/null | wc -l",									"(dnf)"      },
 		{ "qlist -I 2> /dev/null | wc -l",												"(emerge)"   },
@@ -108,6 +109,7 @@ int pkgman() { // this is just a function that returns the total of installed pa
 		{ "pacman -Qq 2> /dev/null | wc -l",											"(pacman)"   },
 		{ "rpm -qa --last 2> /dev/null | wc -l",										"(rpm)"      },
 		{ "xbps-query -l 2> /dev/null | wc -l",											"(xbps)"     }
+		{ "zypper se --installed-only 2> /dev/null | wc -l",							"(zypper)"   }
 	};
 
 	const unsigned long pkgman_count = sizeof(pkgmans) / sizeof(pkgmans[0]);
@@ -335,13 +337,10 @@ void print_ascii() {	// prints logo (as ascii art) of the given system. distribu
  				" %s |  %s|  %s----  %s|\n"
  				" %s  --%s'--------'\n\n",GREEN, WHITE, GREEN, WHITE, GREEN, WHITE, GREEN, WHITE, GREEN, WHITE, GREEN, WHITE, GREEN, WHITE, GREEN, WHITE, GREEN);
 	} else if (strcmp(version_name, "\"opensuse-leap\"") == 0) {
-		printf("\033[2E\033[6C%s_______\n"
-	 			"   ___|   %s__%s \\\n"
-	 			"  /      %s/ o\\%s|\n"
-	 			"         %s\\__/%s|\n"
-				"       ______/\n"
-				"      \\_______\n"
-				"   \\_________/\n\n", GREEN, NORMAL, GREEN, NORMAL, GREEN, NORMAL, GREEN);
+		printf("\033[3E\033[3C%s|\\----/|\n"
+				" _ /   %sO O%s\\\n"
+	 			" __.    W /\n"
+	 			"    '----'\n\n\n", GREEN, WHITE, GREEN);
 	} else if (strcmp(version_name, "pop") == 0) {
 		printf("\033[2E\033[6C%s|\\.-----./|\n"
 	 			"      |/       \\|\n"


### PR DESCRIPTION
1. OpenSUSE's package manager has been added to `pkgmans`.
2. SUSE's icon has also been changed to the following. It might not be... great, but it's better than the vanilla one that's currently implemented. 
![](https://i.imgur.com/Ai1FtKG.png)
3. The distribution section has been divided into two sections; One for distros that are fully supported by UwUfetch (both Ascii art, and images have been implemented), and another for ones that are only partially supported (either no Ascii art, or no image is provided for the distribution).
4.  APT has been reimplemented. The major overhaul of the package manager section in #51 somehow left it out.