### PR TITLE
Fixes 0MB ram. Fixes #61

### DIFF
--- a/uwufetch.c
+++ b/uwufetch.c
@@ -224,7 +224,7 @@ void get_info() {	// get all necessary info
 
 	FILE *meminfo;
 		
-	meminfo = popen("free 2> /dev/null", "r");
+	meminfo = popen("LANG=EN_us free 2> /dev/null", "r");
 	while (fgets(line, sizeof(line), meminfo)) {
 	//	free command prints like this: "Mem:" total	used	free	shared	buff/cache	available
 	


### PR DESCRIPTION
Fixes `uwufetch` giving 0 ram usage and 0 ram max.
The issue is because `free` gives a different output for some languages. Example: In PT_BR `free` gives `Mem.:` instead of `Mem:`.
This PR adds `LANG=EN_us` to the start of the command, so it always run in english language.
Fixes #61 
