### PR TITLE
[FIX] Variable name in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,19 +14,19 @@ debug:
 	./uwufetch
 
 install:
-	cp $(NAME) $(DESTDIR)$(INSTALL_DIR)/$(NAME)
+	cp $(NAME) $(DESTDIR)$(PREFIX)/$(NAME)
 	ls $(DESTDIR)/usr/lib/uwufetch/ 2> /dev/null || mkdir $(DESTDIR)/usr/lib/uwufetch/
 	cp res/* $(DESTDIR)/usr/lib/uwufetch/
 
 uninstall:
-	rm -f $(DESTDIR)$(INSTALL_DIR)/$(NAME)
+	rm -f $(DESTDIR)$(PREFIX)/$(NAME)
 	rm -rf $(DESTDIR)/usr/lib/uwufetch/
 
 termux: build
-	cp $(NAME) $(DESTDIR)/data/data/com.termux/files$(INSTALL_DIR)/$(NAME)
+	cp $(NAME) $(DESTDIR)/data/data/com.termux/files$(PREFIX)/$(NAME)
 	ls $(DESTDIR)/data/data/com.termux/files/usr/lib/uwufetch/ > /dev/null || mkdir $(DESTDIR)/data/data/com.termux/files/usr/lib/uwufetch/
 	cp res/* /data/data/com.termux/files/usr/lib/uwufetch/
 
 termux_uninstall:
-	rm -rf $(DESTDIR)/data/data/com.termux/files$(INSTALL_DIR)/$(NAME)
+	rm -rf $(DESTDIR)/data/data/com.termux/files$(PREFIX)/$(NAME)
 	rm -rf $(DESTDIR)/data/data/com.termux/files/usr/lib/uwufetch/


### PR DESCRIPTION
#63 changes `INSTALL_DIR` in Makefile to `PREFIX` but still use it as `INSTALL_DIR` which makes the install command breaks (installing on `/uwufetch`).

This PR fixes it.