### PR TITLE
Remove # in makefile that prevented gzip from working.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ MAN_COMPILER	= pandoc
 build: $(FILES)
 	$(CC) $(CFLAGS) -o $(NAME) $(FILES)
 	$(MAN_COMPILER) $(NAME)_man.md -st man -o $(NAME).1
-	@#gzip $(NAME).1
+	@gzip $(NAME).1
 
 debug:
 	@clear


### PR DESCRIPTION
You left a `#` in the gzip line in the Makefile, preventing the creation of the .1.gz file; this results in `make install` not working. 