### PR TITLE
[TYPO] fixed typos in CONTRIBUTING.md.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 To contribute to this project, you should follow some rules to keep the code consistent:
 - To indent I like to use tabs in size 4, so you should use them to commit.
 
-- When an the code in an `if` (or `else`) statement is only one line please do not use curly brackets: 
+- When the code in an `if` (or `else`) statement is only one line please do not use curly brackets: 
 ```c
 if (things)
 	something(will_happen);
@@ -17,7 +17,7 @@ else
 	something(!will_happen);
 ```
 
-- When the the code in an `if` (or `else`) statement is too short, write it in one line (if it is readable):
+- When the code in an `if` (or `else`) statement is too short, write it in one line (if it is readable):
 ```c
 if (this) that();
 
@@ -52,4 +52,4 @@ If you are requesting a feature, please specify if you are already working on it
 
 I know that adding this file now is a bit late, but I am writing this anyway, just to appear as a *professional* programmer, even though I am not.
 
-I woult take some space to thank all the [contributors](https://github.com/TheDarkBug/uwufetch/graphs/contributors) that made this project better every day.
+I would take some space to thank all the [contributors](https://github.com/TheDarkBug/uwufetch/graphs/contributors) that made this project better every day.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,7 @@ else nothing();
 - Before pushing the commit, please delete double-new-lines.
 
 #
+
 ## Pull requests
 
 Before sending a pull request be sure that no one is already working on the same thing and to follow this guide-lines.
@@ -39,6 +40,7 @@ Before sending a pull request be sure that no one is already working on the same
 With pull requests you can `[FIX]` a bug (reported or not), add `[OS-SUPPORT]`, add a `[NEW-FEATURE]` requested in an [issue](https://github.com/TheDarkBug/uwufetch/blob/main/CONTRIBUTING.md#issues), fix a `[TYPO]` or `[OPTIMIZE]` the code. For everything else do not use tags.
 
 #
+
 ## Issues
 
 You can use the issues to report bugs with `[BUG]`, to request features `[FEATURE-REQUEST]`, to request support for an os `[OS-SUPPORT]`. For everything else do not use tags.
@@ -48,6 +50,7 @@ If you are reporting a `[BUG]`, please include a screenshot and the output of th
 If you are requesting a feature, please specify if you are already working on it, then send a [pull request](https://github.com/TheDarkBug/uwufetch/blob/main/CONTRIBUTING.md#pull-requests).
 
 #
+
 ## Conclusions
 
 I know that adding this file now is a bit late, but I am writing this anyway, just to appear as a *professional* programmer, even though I am not.


### PR DESCRIPTION
Another thing which should IMO be allowed for code formatting is "Prettier" extension for VSCodium, because it's just a simple way to auto format code and VSCodium (VSCode) is a pretty popular text editor.﻿
