### PR TITLE
Hide resolution by default on headless systems

### DIFF
--- a/uwufetch.c
+++ b/uwufetch.c
@@ -245,8 +245,9 @@ void print_info()
 		printf("\033[18C%s%sWAM         %s%i MB/%i MB\n",
 			   NORMAL, BOLD, NORMAL, (ram_used), ram_total);
 	if (show_resolution)
-		printf("\033[18C%s%sRESOLUTION%s  %dx%d\n",
-				NORMAL, BOLD, NORMAL, screen_width, screen_height);
+		if (screen_width != 0 || screen_height != 0)
+			printf("\033[18C%s%sRESOLUTION%s  %dx%d\n",
+					NORMAL, BOLD, NORMAL, screen_width, screen_height);
 	if (show_shell)
 		printf("\033[18C%s%sSHELL       %s%s\n",
 			   NORMAL, BOLD, NORMAL, shell);
@@ -254,7 +255,7 @@ void print_info()
 		printf("\033[18C%s%sPKGS        %s%s%d %s\n",
 			   NORMAL, BOLD, NORMAL, NORMAL, pkgs, pkgman_name);
 	if (show_uptime)
-		if(sys.uptime/3600 < 24)
+		if (sys.uptime/3600 < 24)
 			printf("\033[18C%s%sUWUPTIME    %s%lih, %lim\n",
 			   NORMAL, BOLD, NORMAL, sys.uptime/3600, sys.uptime/60%60);
 		else


### PR DESCRIPTION
This prevents the resolution from showing "0x0" on headless systems without an X server.