### PR TITLE
rewrite some of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
 # UwUFetch
 
-A meme system info tool for (almost) all your Linux/Unix-based systems, based on nyan/UwU trend on r/linuxmasterrace.
+A meme system info tool for (almost) all your Linux/Unix-based systems, based on the nyan/UwU trend on r/linuxmasterrace.
 
 ## Currently supported distros
 
-#### Full support (Both Ascii art + images are provided for the given distribution)
+### Full support (Both ASCII art + images are provided for the given distribution)
 
 Nyalpine, Nyarch Linuwu, Nyartix Linuwu, Debinyan, endOwO, Fedowa, GentOwO, GnUwU gUwUix, Miwint, Myanjawo, OwOpenSUSE, Pop OwOs, RaspNyan, Swackwawe, sOwOlus, UwUntu, and OwOid; Plus Nyandroid.
 
-#### Partial support (Either no Ascii art, or no image is provided)
+### Partial support (Either no ASCII art, or no image is provided)
 
 KDE NeOwOn, nixOwOs; Plus FweeBSD, OwOpenBSD and macOwOS; Plus WinyandOwOws.
 
 ## Building and installation
 
-#### Requisites
+### Requisites
 
-[viu](https://github.com/atanunq/viu) to use images instead of ascii art.
+- [viu](https://github.com/atanunq/viu) to use images instead of ascii art (see [How to use images](#how-to-use-images) below)
 
-[lshw](https://github.com/lyonel/lshw) to get gpu info.
+- [lshw](https://github.com/lyonel/lshw) to get GPU info.
 
-##### Via package manager
+### Via package manager
 
 Right now, the package is only available on the AUR:
 
@@ -28,13 +28,13 @@ Right now, the package is only available on the AUR:
 
 [![uwufetch-git](https://img.shields.io/aur/version/uwufetch-git?color=1793d1&label=uwufetch-git&logo=arch-linux&style=for-the-badge)](https://aur.archlinux.org/packages/uwufetch-git/)
 
-##### Via source
+### From source
 
-Building requisites:
+Build requisites:
 
--   Make
--   A C compiler
--   `pandoc` to compile man pages
+- Make
+- A C compiler
+- `pandoc` to compile man pages
 
 To install UwUfetch from the source, type these commands in the terminal:
 
@@ -43,7 +43,7 @@ git clone https://github.com/TheDarkBug/uwufetch.git
 cd uwufetch
 make build
 make man
-sudo make install
+sudo make install       # for termux, use `make termux`
 ```
 
 To uninstall:
@@ -53,7 +53,7 @@ cd uwufetch
 sudo make uninstall
 ```
 
-##### Make options:
+#### Available Make targets
 
 ```shell
 make build              # builds uwufetch
@@ -69,17 +69,19 @@ make termux_uninstall   # uninstall for termux
 
 ### How to use images
 
-First at all you need `viu`, to install it follow the [guide](https://github.com/atanunq/viu#installation).
-Images are working in almost every terminal, for a better experience i recommend [kitty](https://github.com/kovidgoyal/kitty)
+First of all, you will need `viu`, which you can install by following the [guide](https://github.com/atanunq/viu#installation).
+
+`viu` supports [kitty](https://github.com/kovidgoyal/kitty) and [iTerm](https://iterm2.com/)'s image protocols.
+If not supported by the current terminal, `viu` uses the fallback Unicode half-block mode (images will look "blocky"), that is the case in many terminal emulators (gnome-terminal, Konsole, etc.). See also: [viu's README](https://github.com/atanunq/viu#description).
 
 ### For copyright and logos info
 
-<font size=2>[COPYRIGHT.md](https://github.com/TheDarkBug/uwufetch/tree/main/res/COPYRIGHT.md)</font>
+See [COPYRIGHT.md](https://github.com/TheDarkBug/uwufetch/tree/main/res/COPYRIGHT.md).
 
 ## License
 
 This program is provided under the [GPL-3.0 License](https://github.com/TheDarkBug/uwufetch/LICENSE).
 
-# Contributing
+## Contributing
 
-All kind of contribution are welcome, but before contributing please read [CONTRIBUTING.md](https://github.com/TheDarkBug/uwufetch/blob/main/CONTRIBUTING.md).
+All kinds of contributions are welcome, but before contributing please read [CONTRIBUTING.md](https://github.com/TheDarkBug/uwufetch/blob/main/CONTRIBUTING.md).

--- a/uwufetch_man.md
+++ b/uwufetch_man.md
@@ -110,7 +110,7 @@ kitty\	\	\ better image viewing
 
 All of this are optional, there is no necessary dependancy.
 
-# LICENSE AND COPYRIGTH
+# LICENSE AND COPYRIGHT
 
 uwufetch is provided under the GPL3 license, for copyright info read\
 https://github.com/TheDarkBug/uwufetch/tree/main/res/COPYRIGHT.md.

--- a/uwufetch_man.md
+++ b/uwufetch_man.md
@@ -102,13 +102,13 @@ uwufetch -d arch\	\	\	\	\	\	\	\	\	\	# prints arch logo\
 uwufetch -\-custom some_image.png\	\	# prints custom image (does not need full path)\
 ueufetch -i -d artix\	\	\	\	\	\	\	\	# prints artix image
 
-# DEPENDANCES
+# DEPENDENCIES
 
 lshw\	\	\	better gpu info\
 viu\	\	\	\ print images instead of ascii logo\
 kitty\	\	\ better image viewing
 
-All of this are optional, there is no necessary dependancy.
+All of these dependencies are optional. There are no required dependencies.
 
 # LICENSE AND COPYRIGHT
 


### PR DESCRIPTION
I noticed some errors in the README and decided to correct them, also added the notice about `viu` only supporting kitty and iterm (see for example [here](https://github.com/TheDarkBug/uwufetch/issues/99#issuecomment-854872719) in issue #99)