### PR TITLE
Fixed output being too high when terminal prompt is at the bottom of the terminal

### DIFF
--- a/uwufetch.c
+++ b/uwufetch.c
@@ -153,8 +153,8 @@ int main(int argc, char *argv[])
 		parse_config();
 	if ((argc == 1 && ascii_image_flag == 0) || (argc > 1 && ascii_image_flag == 0))
 	{
-		printf("\n");
-		printf("\033[1A"); // to align info text
+		printf("\n");	// print a new line
+		printf("\033[1A"); // go up one line if possible
 		print_ascii();
 	}
 	else if (ascii_image_flag == 1)

--- a/uwufetch.c
+++ b/uwufetch.c
@@ -152,7 +152,11 @@ int main(int argc, char *argv[])
 	if (argc == 1)
 		parse_config();
 	if ((argc == 1 && ascii_image_flag == 0) || (argc > 1 && ascii_image_flag == 0))
+	{
+		printf("\n");
+		printf("\033[1A"); // to align info text
 		print_ascii();
+	}
 	else if (ascii_image_flag == 1)
 		print_image();
 	uwu_kernel();


### PR DESCRIPTION
- updated truncate_name method
- fixed #111 (hopefully)
Idk how or why this actually works, it just happened to be the solution after trying to print a lot of different things before the actual output.
