### PR TITLE
Force creation of directories (useful for packaging)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ debug:
 	$(CC) $(CFLAGS_DEBUG) -o $(NAME) $(FILES)
 	./uwufetch
 
-install: build
+install:
 	mkdir -p $(DESTDIR)$(PREFIX) $(DESTDIR)$(LIBDIR)/uwufetch $(DESTDIR)$(MANDIR)
 	cp $(NAME) $(DESTDIR)$(PREFIX)/$(NAME)
 	cp -r res/* $(DESTDIR)$(LIBDIR)/uwufetch

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ debug:
 	./uwufetch
 
 install: build
+	mkdir -p $(DESTDIR)$(PREFIX) $(DESTDIR)$(LIBDIR)/uwufetch $(DESTDIR)$(MANDIR)
 	cp $(NAME) $(DESTDIR)$(PREFIX)/$(NAME)
-	ls $(DESTDIR)$(LIBDIR)/uwufetch > /dev/null || mkdir $(DESTDIR)$(LIBDIR)/uwufetch
 	cp -r res/* $(DESTDIR)$(LIBDIR)/uwufetch
 	cp ./$(NAME).1.gz $(DESTDIR)$(MANDIR)/
 


### PR DESCRIPTION
In packaging systems (*cough* such as the one on Arch Linux *cough*), directories such as `$pkgdir/usr/{bin,lib,share/man/man1}` do not exist yet. Therefore, as it currently stands, there are errors like this:

```
cp: cannot create regular file '/tmp/uwufetch/pkg/uwufetch/usr/bin/uwufetch': No such file or directory
```
Since `/usr/bin` inside of `/tmp/uwufetch/pkg/uwufetch` might not yet exist, we have to create `/usr` first and `/usr/bin` afterwards.
Luckily, `mkdir` has a `-p` switch, which does this for us.