### PR TITLE
Fix compile Error

### DIFF
--- a/uwufetch.c
+++ b/uwufetch.c
@@ -729,7 +729,7 @@ void print_ascii()
 		replace(line, "{LPINK}", LPINK);
 		// For manjaro
 		replace(line, "{BACKGROUND_GREEN}", "\e[0;42m");
-		printf(line);
+		printf("%s", line);
 	}
 	// Always set color to NORMAL, so there's no need to do this in every ascii file.
 	printf(NORMAL);


### PR DESCRIPTION
Fixed:
uwufetch.c: In function ‘print_ascii’:
uwufetch.c:732:10: warning: format not a string literal and no format arguments [-Wformat-security]
  732 |   printf(line);
      |          ^~~~
by adding string argument to printf