### PR TITLE
Fixed errors in L:222 and L:585.

### DIFF
--- a/uwufetch.c
+++ b/uwufetch.c
@@ -218,7 +218,7 @@ void parse_config()
 		}
 	}
 	else
-			config = fopen(config_directory, "r");
+		config = fopen(config_directory, "r");
 	if (config == NULL)
 		return;
 


### PR DESCRIPTION
# Fixes done:
L:222 : <b> <i><code>uninitvar: Uninitialized variable: config
</code></i></b>

<b> FIX:</b> config may not be initialized, so it is given a placeholder value of  `NULL`

L:585:<b> <i><code> resourceLeak: Resource leak: host_model_info
</code></i></b>
<b> FIX:</b> `host_model_info` is closed.