### PR TITLE
check open file before close() for host_model_info

### DIFF
--- a/uwufetch.c
+++ b/uwufetch.c
@@ -666,10 +666,11 @@ void get_info()
 #else
 	FILE *cpuinfo = popen("sysctl -a | egrep -i 'hw.model'", "r");
 #endif
-	FILE *host_model_info = fopen("/sys/devices/virtual/dmi/id/board_name", "r");
-	if (!host_model_info)
-		if ((host_model_info = fopen("/sys/devices/virtual/dmi/id/product_name", "r")) != NULL)
-			fclose(host_model_info);
+	FILE *host_model_info = fopen("/sys/devices/virtual/dmi/id/board_name", "r"); // first try open the file
+	if (!host_model_info) // if failed
+		host_model_info = fopen("/sys/devices/virtual/dmi/id/product_name", "r"); // try open another file
+	if(host_model_info) // if one of the file could be open then close it
+		fclose(host_model_info);
 #ifdef __WINDOWS__
 	host_model_info = popen("wmic computersystem get model", "r");
 	while (fgets(line, sizeof(line), host_model_info))


### PR DESCRIPTION
I changed the check before close() the file (because before if the file wasn't open it would still try to close() it which seg fault).
But then I realised if the first file succeeded to be opened then it wouldn't close it so I changed the check to make it close either if the first or second try succeeded