### PR TITLE
Add link to Pacstall instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,16 @@ KDE NeOwOn, nixOwOs, xuwulinux; Plus FweeBSD, OwOpenBSD, macOwOS and iOwOS; Plus
 
 ### Via package manager
 
-Right now, the package is only available on the AUR:
+From the AUR
 
 [![uwufetch](https://img.shields.io/aur/version/uwufetch?color=1793d1&label=uwufetch&logo=arch-linux&style=for-the-badge)](https://aur.archlinux.org/packages/uwufetch/)
 
 [![uwufetch-git](https://img.shields.io/aur/version/uwufetch-git?color=1793d1&label=uwufetch-git&logo=arch-linux&style=for-the-badge)](https://aur.archlinux.org/packages/uwufetch-git/)
+
+From [Pacstall](https://github.com/pacstall/pacstall#installing)
+```bash
+pacstall -I uwufetch
+```
 
 ### From source
 


### PR DESCRIPTION
[Pacstall](https://github.com/pacstall/pacstall) is a community-driven AUR-like package manager for Ubuntu. We have a [Pacscript](https://github.com/pacstall/pacstall-programs/blob/master/packages/uwufetch/uwufetch.pacscript) for Uwufetch in our repository. With Pacstall, people can install and update Uwufetch without having to go to the download's section on GitHub every update and recompiling.

It can be installed on Ubuntu by running this command (after [Pacstall](https://github.com/pacstall/pacstall#installing) is installed)

```bash
pacstall -I uwufetch
```

It can also be upgraded

```bash
pacstall -Up
```
and removed when requested.

```bash
pacstall -R uwufetch
```