### PR TITLE
Changed the default location of '/usr/lib' to '/usr/local/lib'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ CC = cc
 DESTDIR = /usr
 
 ifeq ($(shell uname), Linux)
-	PREFIX		= local/bin
-	LIBDIR		= local/lib
+	PREFIX		= bin
+	LIBDIR		= lib
 	MANDIR		= share/man/man1
 else ifeq ($(shell uname), Darwin)
 	PREFIX		= local/bin
@@ -16,8 +16,8 @@ else ifeq ($(shell uname), Darwin)
 else ifeq ($(shell uname), FreeBSD)
 	CFLAGS += -D__FREEBSD__
 	CFLAGS_DEBUG += -D__FREEBSD__
-	PREFIX		= local/bin
-	LIBDIR		= local/lib
+	PREFIX		= bin
+	LIBDIR		= lib
 	MANDIR		= share/man/man1
 else ifeq ($(shell uname), windows32)
 	CC 			= gcc

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ CC = cc
 DESTDIR = /usr
 
 ifeq ($(shell uname), Linux)
-	PREFIX		= bin
-	LIBDIR		= lib
+	PREFIX		= local/bin
+	LIBDIR		= local/lib
 	MANDIR		= share/man/man1
 else ifeq ($(shell uname), Darwin)
 	PREFIX		= local/bin
@@ -16,8 +16,8 @@ else ifeq ($(shell uname), Darwin)
 else ifeq ($(shell uname), FreeBSD)
 	CFLAGS += -D__FREEBSD__
 	CFLAGS_DEBUG += -D__FREEBSD__
-	PREFIX		= bin
-	LIBDIR		= lib
+	PREFIX		= local/bin
+	LIBDIR		= local/lib
 	MANDIR		= share/man/man1
 else ifeq ($(shell uname), windows32)
 	CC 			= gcc
@@ -52,6 +52,9 @@ termux: build
 termux_uninstall:
 	rm -rf $(DESTDIR)/data/data/com.termux/files$(PREFIX)/$(NAME)
 	rm -rf $(DESTDIR)/data/data/com.termux/files/usr/lib/uwufetch/
+
+clean:
+	rm $(NAME)
 
 man:
 	gzip --keep $(NAME).1

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ debug:
 	$(CC) $(CFLAGS_DEBUG) -o $(NAME) $(FILES)
 	./$(NAME)
 
-install:
+install: build
 	mkdir -p $(DESTDIR)/$(PREFIX) $(DESTDIR)/$(LIBDIR)/uwufetch $(DESTDIR)/$(MANDIR)
 	cp $(NAME) $(DESTDIR)/$(PREFIX)/$(NAME)
 	cp -r res/* $(DESTDIR)/$(LIBDIR)/uwufetch

--- a/uwufetch.c
+++ b/uwufetch.c
@@ -325,8 +325,10 @@ void print_image(struct info* user_info) {
 	else {
 		if (strcmp(user_info->os_name, "android") == 0)
 			sprintf(command, "viu -t -w 18 -h 8 /data/data/com.termux/files/usr/lib/uwufetch/%s.png 2> /dev/null", user_info->os_name); // image command for android
+		else if (strcmp(user_info->os_name, "macos") == 0)
+			sprintf(command, "viu -t -w 18 -h 8 /usr/local/lib/uwufetch/%s.png 2> /dev/null", user_info->os_name);
 		else
-			sprintf(command, "viu -t -w 18 -h 8 /usr/local/lib/uwufetch/%s.png 2> /dev/null", user_info->os_name); // image command for other systems
+			sprintf(command, "viu -t -w 18 -h 8 /usr/lib/uwufetch/%s.png 2> /dev/null", user_info->os_name); // image command for other systems
 	}
 	printf("\n");
 	if (system(command) != 0) // if viu is not installed or the image is missing
@@ -631,8 +633,10 @@ void print_ascii(struct info* user_info) {
 	if (!file) { // if the file does not exist in the local directory, open it from the installation directory
 		if (strcmp(user_info->os_name, "android") == 0)
 			sprintf(ascii_file, "/data/data/com.termux/files/usr/lib/uwufetch/ascii/%s.txt", user_info->os_name);
-		else
+		else if (strcmp(user_info->os_name, "macos") == 0)
 			sprintf(ascii_file, "/usr/local/lib/uwufetch/ascii/%s.txt", user_info->os_name);
+		else
+			sprintf(ascii_file, "/usr/lib/uwufetch/ascii/%s.txt", user_info->os_name);
 
 		file = fopen(ascii_file, "r");
 		if (!file) {

--- a/uwufetch.c
+++ b/uwufetch.c
@@ -326,7 +326,7 @@ void print_image(struct info* user_info) {
 		if (strcmp(user_info->os_name, "android") == 0)
 			sprintf(command, "viu -t -w 18 -h 8 /data/data/com.termux/files/usr/lib/uwufetch/%s.png 2> /dev/null", user_info->os_name); // image command for android
 		else
-			sprintf(command, "viu -t -w 18 -h 8 /usr/lib/uwufetch/%s.png 2> /dev/null", user_info->os_name); // image command for other systems
+			sprintf(command, "viu -t -w 18 -h 8 /usr/local/lib/uwufetch/%s.png 2> /dev/null", user_info->os_name); // image command for other systems
 	}
 	printf("\n");
 	if (system(command) != 0) // if viu is not installed or the image is missing
@@ -632,7 +632,7 @@ void print_ascii(struct info* user_info) {
 		if (strcmp(user_info->os_name, "android") == 0)
 			sprintf(ascii_file, "/data/data/com.termux/files/usr/lib/uwufetch/ascii/%s.txt", user_info->os_name);
 		else
-			sprintf(ascii_file, "/usr/lib/uwufetch/ascii/%s.txt", user_info->os_name);
+			sprintf(ascii_file, "/usr/local/lib/uwufetch/ascii/%s.txt", user_info->os_name);
 
 		file = fopen(ascii_file, "r");
 		if (!file) {


### PR DESCRIPTION
I have changed the default location from /usr/lib to /usr/local/lib as on macos the /usr/lib is read-only so when running uwufetch from some other folder it will not display any ascii file with an error. I also added a clean function to the makefile