### PR TITLE
[OS-SUPPORT] Fix ETC_DIR for unrooted Android/Termux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ ifeq ($(PLATFORM), Linux)
 	MANDIR		= share/man/man1
 	ifeq ($(shell uname -o), Android)
 		DESTDIR	= /data/data/com.termux/files/usr
+		ETC_DIR = $(DESTDIR)/etc
 	endif
 else ifeq ($(PLATFORM), Darwin)
 	PREFIX		= local/bin

--- a/uwufetch.c
+++ b/uwufetch.c
@@ -162,8 +162,14 @@ struct configuration parse_config(struct info* user_info) {
 			char homedir[512];
 			sprintf(homedir, "%s/.config/uwufetch/config", getenv("HOME"));
 			config = fopen(homedir, "r");
-			if (!config)
-				config = fopen("/etc/uwufetch/config", "r");
+			if (!config) {
+				if(getenv("PREFIX") != NULL) {
+					char prefixed_etc[512];
+					sprintf(prefixed_etc, "%s/etc/uwufetch/config", getenv("PREFIX"));
+					config = fopen(prefixed_etc, "r");
+				} else
+					config = fopen("/etc/uwufetch/config", "r");
+			}
 		}
 	} else
 		config = fopen(user_info->config_directory, "r");


### PR DESCRIPTION
On unrooted phones this will cause permission denied error. Or we are targeting only rooted Android devices?