### PR TITLE
[FIX] Fixed line rollover for small terminals

### DIFF
--- a/uwufetch.c
+++ b/uwufetch.c
@@ -406,7 +406,7 @@ int print_info(struct configuration* config_flags, struct info* user_info) {
 	#define responsively_printf(buf, format, ...)         \
 		{                                                 \
 			sprintf(buf, format, __VA_ARGS__);            \
-			printf("%.*s\n", user_info->ws_col - 1, buf); \
+			printf("%.*s\n", user_info->ws_col - 4, buf); \
 			line_count++;                                 \
 		}
 #else // _WIN32
@@ -414,7 +414,7 @@ int print_info(struct configuration* config_flags, struct info* user_info) {
 	#define responsively_printf(buf, format, ...)             \
 		{                                                     \
 			sprintf(buf, format, __VA_ARGS__);                \
-			printf("%.*s\n", user_info->win.ws_col - 1, buf); \
+			printf("%.*s\n", user_info->win.ws_col - 4, buf); \
 			line_count++;                                     \
 		}
 #endif					  // _WIN32
@@ -467,7 +467,7 @@ int print_info(struct configuration* config_flags, struct info* user_info) {
 		system("ls $(brew --cellar) | wc -l | awk -F' ' '{print \"  \x1b[34m                   \x1b[0m\x1b[1mPKGS\x1b[0m        \"$1 \" (brew)\"}'");
 #else
 	if (config_flags->show_pkgs) // print pkgs
-		responsively_printf(print_buf, "%s%s%sPKGS        %s%s%d: %s", MOVE_CURSOR, NORMAL, BOLD, NORMAL, NORMAL, user_info->pkgs, user_info->pkgman_name);
+		responsively_printf(print_buf, "%s%s%sPKGS        %s%d: %s", MOVE_CURSOR, NORMAL, BOLD, NORMAL, user_info->pkgs, user_info->pkgman_name);
 #endif
 	if (config_flags->show_uptime) { // print uptime
 		if (user_info->uptime == 0) {


### PR DESCRIPTION
When using a small terminal, text would flow over into the image and added an extra line between some of the info.  The cause of this (i think) is that the control characters being printed counted as characters that take up space during the formatting ("%.*s").  There are 4 of these per line, so I changed it to 4 characters cut off.  However, because the PKGS line had an extra 5th unnecessary duplicate "NORMAL" control character, I removed it so that the name of the package manager would not be cut off.

I've attached a before and after screenshot:
WM: dwm-6.3
Term: Alacritty

![uwufetch_grab2](https://user-images.githubusercontent.com/121695438/210158130-6329aa59-1fcf-4583-be57-4a9a402af356.png)

