### PR TITLE
Make logo file paths portable.

### DIFF
--- a/uwufetch.c
+++ b/uwufetch.c
@@ -160,9 +160,9 @@ void print_image(struct info* user_info) {
 		if (strcmp(user_info->os_name, "android") == 0)
 			sprintf(command, "viu -t -w 18 -h 8 /data/data/com.termux/files/usr/lib/uwufetch/%s.png 2> /dev/null", user_info->os_name); // image command for android
 		else if (strcmp(user_info->os_name, "macos") == 0)
-			sprintf(command, "viu -t -w 18 -h 8 /usr/local/lib/uwufetch/%s.png 2> /dev/null", user_info->os_name);
+			sprintf(command, "viu -t -w 18 -h 8 %s/lib/uwufetch/%s.png 2> /dev/null", getenv("DESTDIR"), user_info->os_name);
 		else
-			sprintf(command, "viu -t -w 18 -h 8 /usr/lib/uwufetch/%s.png 2> /dev/null", user_info->os_name); // image command for other systems
+			sprintf(command, "viu -t -w 18 -h 8 %s/lib/uwufetch/%s.png 2> /dev/null", getenv("DESTDIR"), user_info->os_name); // image command for other systems
 	}
 	printf("\n");
 	if (system(command) != 0) // if viu is not installed or the image is missing
@@ -593,9 +593,9 @@ void print_ascii(struct info* user_info) {
 		if (strcmp(user_info->os_name, "android") == 0)
 			sprintf(ascii_file, "/data/data/com.termux/files/usr/lib/uwufetch/ascii/%s.txt", user_info->os_name);
 		else if (strcmp(user_info->os_name, "macos") == 0)
-			sprintf(ascii_file, "/usr/local/lib/uwufetch/ascii/%s.txt", user_info->os_name);
+			sprintf(ascii_file, "%s/lib/uwufetch/ascii/%s.txt", getenv("DESTDIR"), user_info->os_name);
 		else
-			sprintf(ascii_file, "/usr/lib/uwufetch/ascii/%s.txt", user_info->os_name);
+			sprintf(ascii_file, "%s/lib/uwufetch/ascii/%s.txt", getenv("DESTDIR"), user_info->os_name);
 
 		file = fopen(ascii_file, "r");
 		if (!file) {


### PR DESCRIPTION
All this does is use the DESTDIR environment variable in place of /usr for Linux and MacOS targets.

In particular, this is needed to make uwufetch work on Guix and Nix system installations.