### PR TITLE
[FIX] Making the arch package button work

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Dewepyn, FemboyOWOS, KDE NeOwOn, nixOwOs, xuwulinux, Wocky Linuwu; Plus FweeBSD,
 
 Arch (Official Repos)
 
-[![uwufetch](https://img.shields.io/archlinux/v/community/x86_64/uwufetch?label=uwufetch&logo=arch-linux&style=for-the-badge)](https://archlinux.org/packages/community/x86_64/uwufetch/)
+[![uwufetch](https://img.shields.io/archlinux/v/extra/x86_64/uwufetch?label=uwufetch&logo=arch-linux&style=for-the-badge)](https://archlinux.org/packages/extra/x86_64/uwufetch/)
 
 
 From the AUR


### PR DESCRIPTION
This happened when community got merged into extra, this pr only changes "community" with extra to make it work