### PR TITLE
[OPTIMIZE] Add AC trie data structure

### DIFF
--- a/src/actrie.h
+++ b/src/actrie.h
@@ -1,0 +1,1067 @@
+#ifndef _ACTRIE_H_
+#define _ACTRIE_H_ 1
+
+#include <assert.h>  // static_assert
+#include <limits.h>  // CHAR_MAX
+#include <stdbool.h> // bool, true
+#include <stddef.h>  // size_t
+#include <stdint.h>  // uint32_t
+#include <stdlib.h>  // abort
+#include <string.h>  // strlen
+
+/// @brief A function called when memory allocation failed
+inline static void out_of_memory_handler(void) {
+  abort();
+}
+
+enum actrie_constants {
+  ALPHABET_START             = '-',
+  ALPHABET_END               = '}',
+  ALPHABET_LENGTH            = ALPHABET_END - ALPHABET_START + 1,
+  IS_FIND_IGNORECASE_MODE_ON = true,
+};
+
+static_assert(IS_FIND_IGNORECASE_MODE_ON == true || IS_FIND_IGNORECASE_MODE_ON == false, "IS_FIND_IGNORECASE_MODE_ON must be bool");
+static_assert(ALPHABET_START <= 'a' && 'z' <= ALPHABET_END, "Symbols [a; z] must be in the alphabet");
+static_assert(ALPHABET_START > '\0' && ALPHABET_END <= CHAR_MAX);
+
+#if defined(__thiscall)
+  #define actrie_thiscall __thiscall
+#elif defined(__fastcall)
+  #define actrie_thiscall __fastcall
+#else
+  #define actrie_thiscall
+#endif
+
+struct actrie_node_t {
+  // Indexes in array of nodes
+  uint32_t edges[ALPHABET_LENGTH];
+
+  // Index in array of nodes
+  uint32_t suffix_link;
+
+  // Index in array of nodes
+  uint32_t compressed_suffix_link;
+
+  /* Index of the word in the Trie which ends on this node and replacement word in the Trie for word ends on this node
+   * MISSING_SENTIEL if node is not terminal
+   */
+  uint32_t word_index;
+};
+
+struct string_t {
+  const char* c_str;
+  size_t size;
+};
+
+struct vector_actrie_node_t {
+  struct actrie_node_t* data;
+  size_t size;
+  size_t capacity;
+};
+
+struct vector_uint32_t {
+  uint32_t* data;
+  size_t size;
+  size_t capacity;
+};
+
+struct vector_string_t {
+  struct string_t* data;
+  size_t size;
+  size_t capacity;
+};
+
+struct actrie_t {
+  // vector<actrie_node_t>
+  struct vector_actrie_node_t nodes;
+  // vector<uint32_t>
+  struct vector_uint32_t words_lengths;
+  // vector<string_t>
+  struct vector_string_t words_replacement;
+  bool are_links_computed;
+};
+
+/// @brief actrie_t type constructor
+/// @param this_ actrie
+/// @return
+void actrie_thiscall actrie_t_ctor(struct actrie_t* this_);
+
+/// @brief actrie_t type destructor
+/// @param this_ actrie
+/// @return
+void actrie_thiscall actrie_t_dtor(struct actrie_t* this_);
+
+/// @brief Reserves actrie's internal vector with patterns for patterns_capacity patterns to add
+/// @param this_ actrie
+/// @param patterns_capacity amount of patterns that will be added
+/// @return
+void actrie_thiscall actrie_t_reserve_patterns(struct actrie_t* this_, size_t patterns_capacity);
+
+/// @brief Adds pattern to the trie in O(pattern_size)
+/// @param this_ actrie
+/// @param pattern c string representing a pattern
+/// @param pattern_size length of the pattern
+/// @param replacer c string representing a replacer for the pattern
+/// @param replacer_size length of the replacer
+/// @return
+void actrie_thiscall actrie_t_add_pattern_len(struct actrie_t* this_, const char* pattern, size_t pattern_size, const char* replacer, size_t replacer_size);
+
+/// @brief Adds pattern to the trie in O(strlen(pattern))
+/// @param this_ actrie
+/// @param pattern c string representing a pattern
+/// @param replacer c string representing a replacer for the pattern
+/// @return
+static inline void actrie_thiscall actrie_t_add_pattern(struct actrie_t* this_, const char* pattern, const char* replacer) {
+  actrie_t_add_pattern_len(this_, pattern, strlen(pattern), replacer, strlen(replacer));
+}
+
+/// @brief Aho–Corasick deterministic finite-state machine is built on the ordinal trie so it can be used as ordinal trie
+/// @param this_ actrie
+/// @param pattern
+/// @return
+bool actrie_thiscall actrie_t_contains_pattern(const struct actrie_t* this_, const char* pattern);
+
+/// @brief Computes compressed suffix links. This is necessary to do before find and/or replace any patterns in texts.
+/// @param this_ actrie
+/// @return
+void actrie_thiscall actrie_t_compute_links(struct actrie_t* this_);
+
+static inline bool actrie_t_is_ready(const struct actrie_t* this_) {
+  return this_->are_links_computed;
+}
+
+static inline size_t actrie_t_patterns_size(const struct actrie_t* this_) {
+  return this_->words_lengths.size;
+}
+
+static inline size_t actrie_t_nodes_size(const struct actrie_t* this_) {
+  return this_->nodes.size;
+}
+
+/// @brief Callback that is called when the next occurrence is found in the
+///        actrie_t_run_text(const struct actrie_t*, const char*, FindCallback)
+typedef void (*FindCallback)(void* context, const char* found_word, size_t word_length, size_t start_index_in_original_text);
+
+/// @brief Find all occurances of any pattern (defined in this ac trie) in the given text in O(strlen(text))
+/// @param this_ actrie
+/// @param text Text to search pattern occurances in
+/// @param callback_context Context passed to the callback
+/// @param find_callback Callback that is called when the next occurrence is found
+/// @return
+void actrie_thiscall actrie_t_run_text(const struct actrie_t* this_, const char* text, void* callback_context, FindCallback find_callback);
+
+/// @brief Replace first occurance of any pattern (defined in this ac trie) found in the given string
+///        in O(length + |replacement_length - first_occurance_length|)
+/// @param c_string string where first occurance should be replaced
+/// @param length length of the string
+/// @return new length of the string (length changes if occurance is found and strlen(occurance_pattern) != strlen(replacement))
+///         !!! It is caller's responsobility to ensure that c_string buffer will not overflow if length growths
+size_t actrie_thiscall actrie_t_replace_first_occurance_len(const struct actrie_t* this_, char* c_string, size_t length);
+
+/// @brief Replace first occurance of any pattern (defined in this ac trie) found in the given string
+///        in O(strlen(c_string) + |replacement_length - first_occurance_length|)
+/// @param c_string string where first occurance should be replaced
+/// @return new length of the string (length changes if occurance is found and strlen(occurance_pattern) != strlen(replacement))
+///         !!! It is caller's responsobility to ensure that c_string buffer will not overflow if length growths
+static inline size_t actrie_thiscall actrie_t_replace_first_occurance(const struct actrie_t* this_, char* c_string) {
+  return actrie_t_replace_first_occurance_len(this_, c_string, strlen(c_string));
+}
+
+/// @brief Replace all occurances of any pattern (defined in this ac trie) found in the given string
+///        in O(length + sum( |replacement_length - occurance_length| for each pattern occurance) )
+/// @param c_string string where first occurance should be replaced
+/// @param length length of the string
+/// @return new length of the string (length changes if for any pattern strlen(pattern[i]) != strlen(replacement[i]))
+///         !!! It is caller's responsobility to ensure that c_string buffer will not overflow if length growths
+size_t actrie_thiscall actrie_t_replace_all_occurances_len(const struct actrie_t* this_, char* c_string, size_t length);
+
+/// @brief Replace all occurances of any pattern (defined in this ac trie) found in the given string
+///        in O(strlen(c_string) + sum( |replacement_length - occurance_length| for each pattern occurance) )
+/// @param c_string string where first occurance should be replaced
+/// @return new length of the string (length changes if for any pattern strlen(pattern[i]) != strlen(replacement[i]))
+///         !!! It is caller's responsobility to ensure that c_string buffer will not overflow if length growths
+static inline size_t actrie_thiscall actrie_t_replace_all_occurances(const struct actrie_t* this_, char* c_string) {
+  return actrie_t_replace_all_occurances_len(this_, c_string, strlen(c_string));
+}
+
+#include <assert.h> // assert, static_assert
+#include <stdlib.h> // malloc, free
+#include <string.h> // memset
+
+#include "actrie.h"
+
+#if defined(__DEBUG__)
+  #define actrie_assert(Expr) assert(Expr)
+#else
+  #define actrie_assert(Expr)
+#endif
+
+#if defined(__GNUC__)
+  #define actrie_noinline __attribute__((__noinline__))
+#elif defined(_MSC_VER)
+  #define actrie_noinline __declspec(noinline)
+#else
+  #define actrie_noinline
+#endif
+
+#if defined(__GNUC__)
+  #pragma GCC diagnostic ignored "-Wpedantic" // MISSING_SENTIEL and DEFAULT_VECTOR_CAPACITY are not int
+#endif
+
+enum actrie_constants_internal {
+  FAKE_PREROOT_INDEX      = 1,
+  ROOT_INDEX              = 2,
+  NULL_NODE_INDEX         = 0,
+  MISSING_SENTIEL         = (uint32_t)(-1),
+  DEFAULT_VECTOR_CAPACITY = (size_t)(16)
+};
+
+#if defined(__GNUC__)
+  #pragma GCC diagnostic pop
+#endif
+
+static inline void actrie_thiscall actrie_node_t_ctor(struct actrie_node_t* this_) {
+  memset((void*)this_->edges, (int)NULL_NODE_INDEX, sizeof(this_->edges));
+  this_->suffix_link            = NULL_NODE_INDEX;
+  this_->compressed_suffix_link = NULL_NODE_INDEX;
+  this_->word_index             = MISSING_SENTIEL;
+}
+
+static inline bool actrie_thiscall actrie_node_t_is_terminal(const struct actrie_node_t* this_) {
+  return this_->word_index != MISSING_SENTIEL;
+}
+
+static inline void actrie_thiscall string_t_ctor1(struct string_t* this_, const char* c_str) {
+  this_->size = 0;
+  if (c_str == NULL) {
+    this_->c_str = NULL;
+    return;
+  }
+
+  size_t size  = strlen(c_str);
+  char* data   = (char*)malloc(size * sizeof(char));
+  this_->c_str = data;
+  if (data == NULL) {
+    out_of_memory_handler();
+    return;
+  }
+
+  strcpy(data, c_str);
+  this_->size = size;
+}
+
+static inline void actrie_thiscall string_t_ctor2(struct string_t* this_, const char* c_str, size_t size) {
+  this_->size = 0;
+  if (c_str == NULL) {
+    this_->c_str = NULL;
+    return;
+  }
+
+  char* data   = (char*)malloc(size * sizeof(char));
+  this_->c_str = data;
+  if (data == NULL) {
+    out_of_memory_handler();
+    return;
+  }
+
+  strncpy(data, c_str, size);
+  this_->size = size;
+}
+
+static inline void actrie_thiscall string_t_dtor(struct string_t* this_) {
+  this_->size = 0;
+  if (this_->c_str != NULL) {
+    free((void*)this_->c_str);
+    this_->c_str = NULL;
+  }
+}
+
+static inline void actrie_thiscall vector_actrie_node_t_ctor1(struct vector_actrie_node_t* this_, size_t initial_size) {
+  size_t capacity            = ((size_t)DEFAULT_VECTOR_CAPACITY >= initial_size) ? (size_t)DEFAULT_VECTOR_CAPACITY : initial_size;
+  struct actrie_node_t* data = this_->data = (struct actrie_node_t*)malloc(capacity * sizeof(struct actrie_node_t));
+  if (data == NULL) {
+    out_of_memory_handler();
+    return;
+  }
+
+  for (const struct actrie_node_t* data_end = data + initial_size; data != data_end; ++data) {
+    actrie_node_t_ctor(data);
+  }
+
+  this_->size     = initial_size;
+  this_->capacity = capacity;
+}
+
+static inline void actrie_thiscall vector_actrie_node_t_dtor(struct vector_actrie_node_t* this_) {
+  this_->size     = 0;
+  this_->capacity = 0;
+  if (this_->data != NULL) {
+    free(this_->data);
+    this_->data = NULL;
+  }
+}
+
+static void actrie_thiscall vector_actrie_node_t_reserve(struct vector_actrie_node_t* this_, size_t new_capacity) {
+  if (this_->capacity >= new_capacity) {
+    return;
+  }
+
+  struct actrie_node_t* new_data = (struct actrie_node_t*)malloc(new_capacity * sizeof(struct actrie_node_t));
+  if (new_data == NULL) {
+    out_of_memory_handler();
+    return;
+  }
+
+  memcpy(new_data, this_->data, this_->size * sizeof(struct actrie_node_t));
+  free(this_->data);
+  this_->data     = new_data;
+  this_->capacity = new_capacity;
+}
+
+static void actrie_thiscall actrie_noinline vector_actrie_node_t_emplace_back_with_resize(struct vector_actrie_node_t* this_) {
+  size_t size     = this_->size;
+  size_t capacity = this_->capacity;
+  static_assert(DEFAULT_VECTOR_CAPACITY > 0);
+  capacity *= 2; // Must not be 0, because capacity >= DEFAULT_VECTOR_CAPACITY > 0
+  struct actrie_node_t* new_data = (struct actrie_node_t*)malloc(sizeof(struct actrie_node_t) * capacity);
+  if (new_data == NULL) {
+    out_of_memory_handler();
+    return;
+  }
+
+  memcpy(new_data, this_->data, size * sizeof(struct actrie_node_t));
+  actrie_node_t_ctor(new_data + size);
+
+  free(this_->data);
+  this_->data     = new_data;
+  this_->size     = size + 1;
+  this_->capacity = capacity;
+}
+
+static inline void actrie_thiscall vector_actrie_node_t_emplace_back(struct vector_actrie_node_t* this_) {
+  size_t size     = this_->size;
+  size_t capacity = this_->capacity;
+  if (size < capacity) {
+    actrie_node_t_ctor(this_->data + size);
+    this_->size = size + 1;
+    return;
+  }
+
+  // Rare case
+  vector_actrie_node_t_emplace_back_with_resize(this_);
+}
+
+static inline void actrie_thiscall vector_uint32_t_ctor(struct vector_uint32_t* this_) {
+  this_->data     = (uint32_t*)malloc(DEFAULT_VECTOR_CAPACITY * sizeof(uint32_t));
+  this_->size     = 0;
+  this_->capacity = DEFAULT_VECTOR_CAPACITY;
+  if (this_->data == NULL) {
+    this_->capacity = 0;
+    out_of_memory_handler();
+  }
+}
+
+static inline void actrie_thiscall vector_uint32_t_dtor(struct vector_uint32_t* this_) {
+  this_->size     = 0;
+  this_->capacity = 0;
+  if (this_->data != NULL) {
+    free(this_->data);
+    this_->data = NULL;
+  }
+}
+
+static inline void actrie_thiscall vector_uint32_t_reserve(struct vector_uint32_t* this_, size_t new_capacity) {
+  if (this_->capacity >= new_capacity) {
+    return;
+  }
+
+  uint32_t* new_data = (uint32_t*)malloc(new_capacity * sizeof(uint32_t));
+  if (new_data == NULL) {
+    out_of_memory_handler();
+    return;
+  }
+
+  memcpy(new_data, this_->data, this_->size * sizeof(uint32_t));
+  free(this_->data);
+  this_->data     = new_data;
+  this_->capacity = new_capacity;
+}
+
+static void actrie_thiscall actrie_noinline vector_uint32_t_emplace_back1_with_resize(struct vector_uint32_t* this_, uint32_t arg0) {
+  size_t size     = this_->size;
+  size_t capacity = this_->capacity;
+
+  static_assert(DEFAULT_VECTOR_CAPACITY > 0);
+  actrie_assert(capacity >= DEFAULT_VECTOR_CAPACITY);
+  capacity *= 2; // Must not be 0, because capacity >= DEFAULT_VECTOR_CAPACITY > 0
+  uint32_t* new_data = (uint32_t*)malloc(sizeof(uint32_t) * capacity);
+  if (new_data == NULL) {
+    out_of_memory_handler();
+    return;
+  }
+
+  memcpy(new_data, this_->data, size * sizeof(uint32_t));
+  *(new_data + size) = arg0;
+
+  free(this_->data);
+  this_->data     = new_data;
+  this_->size     = size + 1;
+  this_->capacity = capacity;
+}
+
+static inline void actrie_thiscall vector_uint32_t_emplace_back1(struct vector_uint32_t* this_, uint32_t arg0) {
+  size_t size     = this_->size;
+  size_t capacity = this_->capacity;
+  if (size < capacity) {
+    *(this_->data + size) = arg0;
+    this_->size           = size + 1;
+    return;
+  }
+
+  // Rare case
+  vector_uint32_t_emplace_back1_with_resize(this_, arg0);
+}
+
+static inline void actrie_thiscall vector_string_t_ctor(struct vector_string_t* this_) {
+  this_->data     = (struct string_t*)malloc(DEFAULT_VECTOR_CAPACITY * sizeof(struct string_t));
+  this_->size     = 0;
+  this_->capacity = DEFAULT_VECTOR_CAPACITY;
+  if (this_->data == NULL) {
+    this_->capacity = 0;
+    out_of_memory_handler();
+  }
+}
+
+static inline void actrie_thiscall vector_string_t_dtor(struct vector_string_t* this_) {
+  struct string_t* data = this_->data;
+  if (data != NULL) {
+    for (const struct string_t* data_end = data + (this_->size); data != data_end; ++data) {
+      string_t_dtor(data);
+    }
+
+    free(this_->data);
+    this_->data = NULL;
+  }
+
+  this_->size = this_->capacity = 0;
+}
+
+static inline void actrie_thiscall vector_string_t_reserve(struct vector_string_t* this_, size_t new_capacity) {
+  if (this_->capacity >= new_capacity) {
+    return;
+  }
+
+  struct string_t* new_data = (struct string_t*)malloc(new_capacity * sizeof(struct string_t));
+  if (new_data == NULL) {
+    out_of_memory_handler();
+    return;
+  }
+
+  memcpy(new_data, this_->data, this_->size * sizeof(struct string_t));
+  free(this_->data);
+  this_->data     = new_data;
+  this_->capacity = new_capacity;
+}
+
+static void actrie_thiscall actrie_noinline vector_string_t_emplace_back2_with_resize(struct vector_string_t* this_, const char* c_string, size_t c_string_size) {
+  size_t size     = this_->size;
+  size_t capacity = this_->capacity;
+
+  static_assert(DEFAULT_VECTOR_CAPACITY > 0);
+  actrie_assert(capacity >= DEFAULT_VECTOR_CAPACITY);
+  capacity *= 2; // Must not be 0, because capacity >= DEFAULT_VECTOR_CAPACITY > 0
+  struct string_t* new_data = (struct string_t*)malloc(sizeof(struct string_t) * capacity);
+  if (new_data == NULL) {
+    out_of_memory_handler();
+    return;
+  }
+
+  memcpy(new_data, this_->data, size * sizeof(struct string_t));
+  string_t_ctor2(new_data + size, c_string, c_string_size);
+
+  free(this_->data);
+  this_->data     = new_data;
+  this_->size     = size + 1;
+  this_->capacity = capacity;
+}
+
+static inline void actrie_thiscall vector_string_t_emplace_back2(struct vector_string_t* this_, const char* c_string, size_t c_string_size) {
+  size_t size = this_->size;
+  if (size < this_->capacity) {
+    string_t_ctor2(this_->data + size, c_string, c_string_size);
+    this_->size = size + 1;
+    return;
+  }
+
+  vector_string_t_emplace_back2_with_resize(this_, c_string, c_string_size);
+}
+
+struct replacement_info_t {
+  uint32_t word_l_index_in_text;
+  uint32_t word_index;
+};
+
+struct vector_replacement_info_t {
+  struct replacement_info_t* data;
+  size_t size;
+  size_t capacity;
+};
+
+static inline void actrie_thiscall vector_replacement_info_t_ctor(struct vector_replacement_info_t* this_) {
+  this_->data     = (struct replacement_info_t*)malloc(DEFAULT_VECTOR_CAPACITY * sizeof(struct replacement_info_t));
+  this_->size     = 0;
+  this_->capacity = DEFAULT_VECTOR_CAPACITY;
+  if (this_->data == NULL) {
+    this_->capacity = 0;
+    out_of_memory_handler();
+  }
+}
+
+static inline void actrie_thiscall vector_replacement_info_t_dtor(struct vector_replacement_info_t* this_) {
+  struct replacement_info_t* data = this_->data;
+  if (data != NULL) {
+    free(data);
+    this_->data = NULL;
+  }
+
+  this_->size = this_->capacity = 0;
+}
+
+static void actrie_thiscall actrie_noinline vector_replacement_info_t_emplace_back2_with_resize(struct vector_replacement_info_t* this_, uint32_t word_l_index_in_text, uint32_t word_index) {
+  size_t size     = this_->size;
+  size_t capacity = this_->capacity;
+
+  static_assert(DEFAULT_VECTOR_CAPACITY > 0);
+  actrie_assert(capacity >= DEFAULT_VECTOR_CAPACITY);
+  capacity *= 2; // Must not be 0, because capacity >= DEFAULT_VECTOR_CAPACITY > 0
+  struct replacement_info_t* new_data = (struct replacement_info_t*)malloc(sizeof(struct replacement_info_t) * capacity);
+  if (new_data == NULL) {
+    out_of_memory_handler();
+    return;
+  }
+
+  memcpy(new_data, this_->data, size * sizeof(struct string_t));
+  new_data[size].word_l_index_in_text = word_l_index_in_text;
+  new_data[size].word_index           = word_index;
+
+  free(this_->data);
+  this_->data     = new_data;
+  this_->size     = size + 1;
+  this_->capacity = capacity;
+}
+
+static inline void actrie_thiscall vector_replacement_info_t_emplace_back2(struct vector_replacement_info_t* this_, uint32_t word_l_index_in_text, uint32_t word_index) {
+  size_t size = this_->size;
+  if (size < this_->capacity) {
+    (this_->data + size)->word_l_index_in_text = word_l_index_in_text;
+    (this_->data + size)->word_index           = word_index;
+    this_->size                                = size + 1;
+    return;
+  }
+
+  // Rare case
+  vector_replacement_info_t_emplace_back2_with_resize(this_, word_l_index_in_text, word_index);
+}
+
+static inline bool is_in_alphabet(char c) {
+  return (uint32_t)(c)-ALPHABET_START <= ALPHABET_END - ALPHABET_START;
+}
+
+static inline bool is_upper(char c) {
+  return (uint32_t)(c) - 'A' <= 'Z' - 'A';
+}
+
+static inline bool is_lower(char c) {
+  return (uint32_t)(c) - 'a' <= 'z' - 'a';
+}
+
+static inline char to_upper(char c) {
+  return (char)((c) - (('a' - 'A') * is_lower(c)));
+}
+
+static inline char to_lower(char c) {
+  return (char)((c) | (('a' - 'A') * is_upper(c)));
+}
+
+static inline size_t char_to_edge_index(char c) {
+  return (size_t)(uint8_t)(c)-ALPHABET_START;
+}
+
+#define constexpr_is_upper(c) ((uint32_t)(c) - 'A' <= 'Z' - 'A')
+#define constexpr_is_lower(c) ((uint32_t)(c) - 'a' <= 'z' - 'a')
+#define constexpr_to_upper(c) (char)((c) - (('a' - 'A') * constexpr_is_lower(c)))
+#define constexpr_to_lower(c) (char)((c) | (('a' - 'A') * constexpr_is_upper(c)))
+#define constexpr_char_to_edge_index(c) ((size_t)(uint8_t)(c)-ALPHABET_START)
+
+static_assert(constexpr_to_upper('\0') == '\0');
+static_assert(constexpr_to_upper('0') == '0');
+static_assert(constexpr_to_upper('9') == '9');
+static_assert(constexpr_to_upper('A') == 'A');
+static_assert(constexpr_to_upper('Z') == 'Z');
+static_assert(constexpr_to_upper('a') == 'A');
+static_assert(constexpr_to_upper('z') == 'Z');
+static_assert(constexpr_to_upper('~') == '~');
+static_assert(constexpr_to_upper('{') == '{');
+static_assert(constexpr_to_upper('}') == '}');
+
+static_assert(constexpr_to_lower('\0') == '\0');
+static_assert(constexpr_to_lower('0') == '0');
+static_assert(constexpr_to_lower('9') == '9');
+static_assert(constexpr_to_lower('A') == 'a');
+static_assert(constexpr_to_lower('Z') == 'z');
+static_assert(constexpr_to_lower('a') == 'a');
+static_assert(constexpr_to_lower('z') == 'z');
+static_assert(constexpr_to_lower('~') == '~');
+static_assert(constexpr_to_lower('{') == '{');
+static_assert(constexpr_to_lower('}') == '}');
+
+static_assert(constexpr_char_to_edge_index(constexpr_to_upper('A')) == constexpr_char_to_edge_index('A'));
+static_assert(constexpr_char_to_edge_index(constexpr_to_upper('Z')) == constexpr_char_to_edge_index('Z'));
+static_assert(constexpr_char_to_edge_index(constexpr_to_upper('a')) == constexpr_char_to_edge_index('A'));
+static_assert(constexpr_char_to_edge_index(constexpr_to_upper('z')) == constexpr_char_to_edge_index('Z'));
+static_assert(constexpr_char_to_edge_index(constexpr_to_upper('~')) == constexpr_char_to_edge_index('~'));
+static_assert(constexpr_char_to_edge_index(constexpr_to_upper('{')) == constexpr_char_to_edge_index('{'));
+static_assert(constexpr_char_to_edge_index(constexpr_to_upper('}')) == constexpr_char_to_edge_index('}'));
+
+static_assert(constexpr_char_to_edge_index(constexpr_to_lower('A')) == constexpr_char_to_edge_index('a'));
+static_assert(constexpr_char_to_edge_index(constexpr_to_lower('Z')) == constexpr_char_to_edge_index('z'));
+static_assert(constexpr_char_to_edge_index(constexpr_to_lower('a')) == constexpr_char_to_edge_index('a'));
+static_assert(constexpr_char_to_edge_index(constexpr_to_lower('z')) == constexpr_char_to_edge_index('z'));
+static_assert(constexpr_char_to_edge_index(constexpr_to_lower('~')) == constexpr_char_to_edge_index('~'));
+static_assert(constexpr_char_to_edge_index(constexpr_to_lower('{')) == constexpr_char_to_edge_index('{'));
+static_assert(constexpr_char_to_edge_index(constexpr_to_lower('}')) == constexpr_char_to_edge_index('}'));
+
+#undef constexpr_char_to_edge_index
+#undef constexpr_to_lower
+#undef constexpr_to_upper
+#undef constexpr_is_lower
+#undef constexpr_is_upper
+
+void actrie_thiscall actrie_t_ctor(struct actrie_t* this_) {
+  vector_actrie_node_t_ctor1(&this_->nodes, 3);
+  vector_uint32_t_ctor(&this_->words_lengths);
+  vector_string_t_ctor(&this_->words_replacement);
+
+  /* link(root) = fake_vertex;
+   * For all chars from the alphabet: fake_vertex ---char--> root
+   */
+
+  struct actrie_node_t* root   = &this_->nodes.data[ROOT_INDEX];
+  root->suffix_link            = FAKE_PREROOT_INDEX;
+  root->compressed_suffix_link = ROOT_INDEX;
+
+  struct actrie_node_t* fake_preroot = &this_->nodes.data[FAKE_PREROOT_INDEX];
+  for (uint32_t *iter = fake_preroot->edges, *end = iter + ALPHABET_LENGTH; iter != end; ++iter) {
+    *iter = ROOT_INDEX;
+  }
+
+  this_->are_links_computed = false;
+}
+
+void actrie_thiscall actrie_t_dtor(struct actrie_t* this_) {
+  vector_actrie_node_t_dtor(&this_->nodes);
+  vector_uint32_t_dtor(&this_->words_lengths);
+  vector_string_t_dtor(&this_->words_replacement);
+  this_->are_links_computed = false;
+}
+
+void actrie_thiscall actrie_t_reserve_patterns(struct actrie_t* this_, size_t patterns_capacity) {
+  vector_uint32_t_reserve(&this_->words_lengths, this_->words_lengths.size + patterns_capacity);
+  vector_string_t_reserve(&this_->words_replacement, this_->words_replacement.size + patterns_capacity);
+}
+
+void actrie_thiscall actrie_t_add_pattern_len(struct actrie_t* this_, const char* pattern, size_t pattern_size, const char* replacer, size_t replacer_size) {
+  uint32_t current_node_index   = ROOT_INDEX;
+  const char* pattern_iter      = pattern;
+  const char* const pattern_end = pattern + pattern_size;
+
+  for (; pattern_iter != pattern_end; ++pattern_iter) {
+    char c = IS_FIND_IGNORECASE_MODE_ON ? to_lower(*pattern_iter) : *pattern_iter;
+    if (!is_in_alphabet(c)) {
+      actrie_assert(!"char in pattern is not in alphabet!!!");
+      continue;
+    }
+
+    uint32_t next_node_index = this_->nodes.data[current_node_index].edges[char_to_edge_index(c)];
+    if (next_node_index != NULL_NODE_INDEX) {
+      current_node_index = next_node_index;
+    } else {
+      break;
+    }
+  }
+
+  size_t lasted_max_length = (size_t)(pattern_end - pattern_iter);
+  vector_actrie_node_t_reserve(&this_->nodes, this_->nodes.size + lasted_max_length);
+
+  /* Inserts substring [i..length - 1] of pattern if i < length (<=> i != length)
+   * If i == length, then for cycle will no execute
+   */
+  for (; pattern_iter != pattern_end; ++pattern_iter) {
+    char c = IS_FIND_IGNORECASE_MODE_ON ? to_lower(*pattern_iter) : *pattern_iter;
+    if (!is_in_alphabet(c)) {
+      actrie_assert(!"char in pattern is not in alphabet!!!");
+      continue;
+    }
+
+    uint32_t new_node_index = (uint32_t)this_->nodes.size;
+    vector_actrie_node_t_emplace_back(&this_->nodes);
+    this_->nodes.data[current_node_index].edges[char_to_edge_index(c)] = new_node_index;
+    current_node_index                                                 = new_node_index; // Actually new_node_index = current_node_index + 1
+  }
+
+  uint32_t word_index                              = (uint32_t)(this_->words_lengths.size);
+  this_->nodes.data[current_node_index].word_index = word_index;
+  vector_uint32_t_emplace_back1(&this_->words_lengths, (uint32_t)pattern_size);
+  vector_string_t_emplace_back2(&this_->words_replacement, replacer, replacer_size);
+}
+
+bool actrie_thiscall actrie_t_contains_pattern(const struct actrie_t* this_, const char* pattern) {
+  uint32_t current_node_index         = ROOT_INDEX;
+  const struct actrie_node_t* m_nodes = this_->nodes.data;
+
+  for (char sigma = IS_FIND_IGNORECASE_MODE_ON ? to_lower(*pattern) : *pattern;
+       sigma != '\0';
+       ++pattern, sigma = IS_FIND_IGNORECASE_MODE_ON ? to_lower(*pattern) : *pattern) {
+    if (!is_in_alphabet(sigma)) {
+      return false;
+    }
+
+    uint32_t next_node_index = m_nodes[current_node_index].edges[char_to_edge_index(sigma)];
+    if (next_node_index != NULL_NODE_INDEX) {
+      current_node_index = next_node_index;
+    } else {
+      return false;
+    }
+  }
+
+  return actrie_node_t_is_terminal(&m_nodes[current_node_index]);
+}
+
+#if defined(__DEBUG__)
+static inline void actrie_thiscall actrie_t_check_computed_links(struct actrie_t* this_) {
+  const struct actrie_node_t* iter     = this_->nodes.data;
+  const struct actrie_node_t* iter_end = iter + this_->nodes.size;
+
+  uint32_t max_node_index_excl = (uint32_t)(this_->nodes.size);
+  actrie_assert(max_node_index_excl >= 3);
+  uint32_t max_word_end_index_excl = (uint32_t)(this_->words_lengths.size);
+  actrie_assert(this_->words_replacement.size == max_word_end_index_excl);
+
+  ++iter;
+  // Now iter points to fake preroot node
+  // fake preroot node does not have suffix_link_index and compressed_suffix_link
+  // all children point to root
+  for (const uint32_t *child_start = iter->edges, *child_end = child_start + sizeof(iter->edges) / sizeof(iter->edges[0]); child_start != child_end; ++child_start) {
+    actrie_assert(*child_start == ROOT_INDEX);
+  }
+
+  for (++iter; iter != iter_end; ++iter) {
+    for (const uint32_t *child_start = iter->edges, *child_end = child_start + sizeof(iter->edges) / sizeof(iter->edges[0]); child_start != child_end; ++child_start) {
+      uint32_t child = *child_start;
+      actrie_assert(child >= FAKE_PREROOT_INDEX && child < max_node_index_excl);
+    }
+
+    uint32_t suffix_link_index = iter->suffix_link;
+    actrie_assert(suffix_link_index >= FAKE_PREROOT_INDEX && suffix_link_index < max_node_index_excl);
+
+    uint32_t compressed_suffix_link_index = iter->compressed_suffix_link;
+    actrie_assert(compressed_suffix_link_index >= FAKE_PREROOT_INDEX && compressed_suffix_link_index < max_node_index_excl);
+
+    actrie_assert(actrie_node_t_is_terminal(iter) == (iter->word_index < max_word_end_index_excl));
+  }
+
+  this_->are_links_computed = true;
+}
+#endif
+
+void actrie_thiscall actrie_t_compute_links(struct actrie_t* this_) {
+  actrie_assert(!this_->are_links_computed);
+
+  struct actrie_node_t* m_nodes = this_->nodes.data;
+
+  /*
+   * See MIPT lecture https://youtu.be/MEFrIcGsw1o for more info
+   *
+   * For each char (marked as sigma) in the Alphabet:
+   *   v := root_eges[sigma] <=> to((root, sigma))
+   *
+   *   root_edges[c] = root_edges[c] ? root_edegs[c] : root
+   *   <=>
+   *   to((root, sigma)) = to((root, sigma)) if (root, sigma) in rng(to) else root
+   *
+   *   link(v) = root (if v aka to((root, sigma)) exists)
+   *
+   *   rood_edges[sigma].compressed_suffix_link = root
+   */
+
+  // Run BFS through all nodes.
+  // BFS queue with known max size
+  uint32_t* const bfs_queue = (uint32_t*)malloc(sizeof(uint32_t) * (this_->nodes.size + 1));
+  if (bfs_queue == NULL) {
+    out_of_memory_handler();
+    return;
+  }
+
+  size_t queue_head_index       = 0;
+  size_t queue_tail_index       = 0;
+  bfs_queue[queue_tail_index++] = ROOT_INDEX;
+
+  while (queue_head_index < queue_tail_index) {
+    uint32_t vertex_index = bfs_queue[queue_head_index++];
+
+    // to(v, sigma) === vertex.edges[sigma]
+    uint32_t* vertex_edges = m_nodes[vertex_index].edges;
+
+    actrie_assert(m_nodes[vertex_index].suffix_link != NULL_NODE_INDEX);
+
+    // to((link(v), sigma)) === m_nodes[vertex.suffix_link].edges[sigma]
+    const uint32_t* vertex_suffix_link_edges = m_nodes[m_nodes[vertex_index].suffix_link].edges;
+
+    // v --sigma-> u is a path from node u to node v via the char sigma
+    // For each char (sigma) in the Alphabet vertex_edges[sigma] is the child such: v --sigma--> child
+    for (size_t sigma = 0; sigma != ALPHABET_LENGTH; sigma++) {
+      actrie_assert(vertex_suffix_link_edges[sigma] != NULL_NODE_INDEX);
+
+      // child = to(v, sigma)
+      uint32_t child_index = vertex_edges[sigma];
+
+      // to((v, sigma)) = to((v, sigma)) if (v, sigma) in the rng(to) else to((link(v), sigma))
+      // rng(to) is a range of function 'to'
+      if (child_index != NULL_NODE_INDEX) {
+        // link(to(v, sigma)) = to((link(v), sigma)) if (v, sigma) in the rng(to)
+        uint32_t child_link_v_index = vertex_suffix_link_edges[sigma];
+
+        struct actrie_node_t* child = &m_nodes[child_index];
+        child->suffix_link          = child_link_v_index;
+
+        actrie_assert(m_nodes[child_link_v_index].compressed_suffix_link != NULL_NODE_INDEX);
+
+        // comp(v) = link(v) if (link(v) is terminal or root) else comp(link(v))
+        child->compressed_suffix_link =
+            ((!actrie_node_t_is_terminal(&m_nodes[child_link_v_index])) & (child_link_v_index != ROOT_INDEX))
+                ? m_nodes[child_link_v_index].compressed_suffix_link
+                : child_link_v_index;
+
+        bfs_queue[queue_tail_index++] = child_index;
+      } else {
+        vertex_edges[sigma] = vertex_suffix_link_edges[sigma];
+      }
+    }
+  }
+
+  free(bfs_queue);
+
+#if defined(__DEBUG__)
+  actrie_t_check_computed_links(this_);
+#endif
+}
+
+void actrie_thiscall actrie_t_run_text(const struct actrie_t* this_, const char* text, void* callback_context, FindCallback find_callback) {
+  actrie_assert(find_callback != NULL);
+  actrie_assert(actrie_t_is_ready(this_));
+
+  const struct actrie_node_t* m_nodes = this_->nodes.data;
+  const uint32_t* m_words_lengths     = this_->words_lengths.data;
+
+  uint32_t current_node_index = ROOT_INDEX;
+  size_t i                    = 0;
+  char c;
+  for (const char* text_iter = text;
+       (c = IS_FIND_IGNORECASE_MODE_ON ? to_lower(*text_iter) : *text_iter) != '\0';
+       ++i, ++text_iter) {
+    if (!is_in_alphabet(c)) {
+      current_node_index = ROOT_INDEX;
+      continue;
+    }
+
+    current_node_index = m_nodes[current_node_index].edges[char_to_edge_index(c)];
+    actrie_assert(current_node_index != NULL_NODE_INDEX);
+    const struct actrie_node_t* current_node = m_nodes + current_node_index;
+    if (actrie_node_t_is_terminal(current_node)) {
+      actrie_assert(current_node->word_index < this_->words_lengths.size);
+      size_t word_length = m_words_lengths[current_node->word_index];
+      size_t l           = i + 1 - word_length;
+      find_callback(callback_context, text + l, word_length, l);
+    }
+
+    // Jump up through compressed suffix links
+    for (uint32_t tmp_node_index = current_node->compressed_suffix_link; tmp_node_index != ROOT_INDEX; tmp_node_index = m_nodes[tmp_node_index].compressed_suffix_link) {
+      actrie_assert(tmp_node_index != NULL_NODE_INDEX);
+      actrie_assert(actrie_node_t_is_terminal(&m_nodes[tmp_node_index]));
+      size_t word_index = m_nodes[tmp_node_index].word_index;
+      actrie_assert(word_index < this_->words_lengths.size);
+      size_t word_length = m_words_lengths[word_index];
+      size_t l           = i + 1 - word_length;
+      find_callback(callback_context, text + l, word_length, l);
+    }
+  }
+}
+
+size_t actrie_thiscall actrie_t_replace_first_occurance_len(const struct actrie_t* this_, char* c_string, size_t length) {
+  actrie_assert(actrie_t_is_ready(this_));
+
+  uint32_t r_index_in_current_substring = 0;
+  uint32_t word_index                   = 0;
+
+  uint32_t current_node_index         = ROOT_INDEX;
+  const struct actrie_node_t* m_nodes = this_->nodes.data;
+  char c;
+  for (const char* iter = c_string;
+       (c = IS_FIND_IGNORECASE_MODE_ON ? to_lower(*iter) : *iter) != '\0';
+       ++iter) {
+    if (!is_in_alphabet(c)) {
+      current_node_index = ROOT_INDEX;
+      continue;
+    }
+
+    current_node_index = m_nodes[current_node_index].edges[char_to_edge_index(c)];
+    actrie_assert(current_node_index != NULL_NODE_INDEX);
+
+    const struct actrie_node_t* current_node = m_nodes + current_node_index;
+    bool current_node_is_terminal            = actrie_node_t_is_terminal(current_node);
+    size_t compressed_suffix_link            = current_node->compressed_suffix_link;
+
+    if (current_node_is_terminal | (compressed_suffix_link != ROOT_INDEX)) {
+      if (current_node_is_terminal) {
+        word_index = current_node->word_index;
+      } else {
+        actrie_assert(actrie_node_t_is_terminal(&m_nodes[compressed_suffix_link]));
+        word_index = m_nodes[compressed_suffix_link].word_index;
+      }
+
+      actrie_assert(word_index < this_->words_lengths.size);
+      r_index_in_current_substring = (uint32_t)(iter - c_string);
+
+      uint32_t word_length = this_->words_lengths.data[word_index];
+
+      // Matched pattern is c_string[l; r]
+      uint32_t l                = r_index_in_current_substring + 1 - word_length;
+      size_t replacement_length = this_->words_replacement.data[word_index].size;
+
+      if (replacement_length != word_length) {
+        // In both cases: replacement_length > word_length || replacement_length < word_length code is the same
+        memmove(c_string + l + replacement_length, c_string + r_index_in_current_substring + 1, length - 1 - r_index_in_current_substring);
+        length += (replacement_length - word_length);
+        c_string[length] = '\0';
+      }
+
+      memcpy(c_string + l, this_->words_replacement.data[word_index].c_str, replacement_length);
+      break;
+    }
+  }
+
+  return length;
+}
+
+size_t actrie_thiscall actrie_t_replace_all_occurances_len(const struct actrie_t* this_, char* c_string, size_t length) {
+  actrie_assert(actrie_t_is_ready(this_));
+#if defined(__DEBUG__)
+  size_t total_copied = 0;
+#endif
+
+  struct vector_replacement_info_t queue;
+  vector_replacement_info_t_ctor(&queue);
+
+  const struct actrie_node_t* m_nodes        = this_->nodes.data;
+  const uint32_t* m_words_lengths            = this_->words_lengths.data;
+  const struct string_t* m_words_replacement = this_->words_replacement.data;
+
+  size_t new_length = length;
+
+  uint32_t current_node_index = ROOT_INDEX;
+  char c;
+  for (char *current_c_string = c_string, *iter = current_c_string;
+       (c = IS_FIND_IGNORECASE_MODE_ON ? to_lower(*iter) : *iter) != '\0';
+       ++iter) {
+    if (!is_in_alphabet(c)) {
+      current_node_index = ROOT_INDEX;
+      continue;
+    }
+
+    current_node_index = m_nodes[current_node_index].edges[char_to_edge_index(c)];
+    actrie_assert(current_node_index != NULL_NODE_INDEX);
+
+    const struct actrie_node_t* current_node = m_nodes + current_node_index;
+    bool current_node_is_terminal            = actrie_node_t_is_terminal(current_node);
+    size_t compressed_suffix_link            = current_node->compressed_suffix_link;
+
+    if (current_node_is_terminal | (compressed_suffix_link != ROOT_INDEX)) {
+      actrie_assert(current_node_is_terminal || actrie_node_t_is_terminal(&m_nodes[compressed_suffix_link]));
+      uint32_t word_index = current_node_is_terminal ? current_node->word_index : m_nodes[compressed_suffix_link].word_index;
+
+      actrie_assert(word_index < this_->words_lengths.size);
+      uint32_t r_index_in_current_substring = (uint32_t)(iter - current_c_string);
+      uint32_t word_length                  = m_words_lengths[word_index];
+      // Matched pattern is current_c_string[l; r]
+      uint32_t l_index_in_current_substring = r_index_in_current_substring + 1 - word_length;
+      size_t replacement_length             = m_words_replacement[word_index].size;
+
+      if ((queue.size == 0) & (word_length == replacement_length)) {
+        char* dst_address = current_c_string + l_index_in_current_substring;
+        actrie_assert(c_string <= dst_address && dst_address + word_length <= c_string + length);
+        memcpy(dst_address, m_words_replacement[word_index].c_str, word_length);
+#if defined(__DEBUG__)
+        total_copied += word_length;
+#endif
+      } else {
+        uint32_t word_l_index_in_text = (uint32_t)(current_c_string + l_index_in_current_substring - c_string);
+        vector_replacement_info_t_emplace_back2(&queue, word_l_index_in_text, word_index);
+        new_length += (replacement_length - word_length);
+      }
+
+      current_c_string   = iter + 1;
+      current_node_index = ROOT_INDEX;
+    }
+  }
+
+  size_t right_offset = 0;
+  for (const struct replacement_info_t *iter_end = queue.data - 1, *iter = iter_end + queue.size; iter != iter_end; --iter) {
+    uint32_t word_index           = iter->word_index;
+    uint32_t word_l_index_in_text = iter->word_l_index_in_text;
+    uint32_t word_length          = m_words_lengths[word_index];
+    size_t moved_part_length      = length - (word_l_index_in_text + word_length);
+
+    char* dst_address       = c_string + (new_length - right_offset - moved_part_length);
+    const char* src_address = c_string + word_l_index_in_text + word_length;
+
+    if (dst_address != src_address) {
+      // If pattern length != replacement length, worth checking
+      actrie_assert((c_string <= dst_address) & (dst_address + moved_part_length <= c_string + (new_length >= length ? new_length : length)));
+      actrie_assert((c_string <= src_address) & (src_address + moved_part_length <= c_string + (new_length >= length ? new_length : length)));
+      memmove(dst_address, src_address, moved_part_length);
+    }
+
+    size_t replacement_length = m_words_replacement[word_index].size;
+    dst_address -= replacement_length;
+
+    actrie_assert((c_string <= dst_address) & (dst_address + replacement_length <= c_string + (new_length >= length ? new_length : length)));
+    memcpy(dst_address, m_words_replacement[word_index].c_str, replacement_length);
+
+    length = word_l_index_in_text;
+    right_offset += moved_part_length + replacement_length;
+#if defined(__DEBUG__)
+    total_copied += moved_part_length + replacement_length;
+#endif
+  }
+
+  vector_replacement_info_t_dtor(&queue);
+
+#if defined(__DEBUG__)
+  // Check for O(length + sum( |replacement_length - occurance_length| for each pattern occurance) ) complexity
+  actrie_assert(total_copied <= new_length);
+#endif
+
+  c_string[new_length] = '\0';
+  return new_length;
+}
+
+#if defined(actrie_noinline)
+  #undef actrie_noinline
+#endif
+
+#if defined(actrie_assert)
+  #undef actrie_assert
+#endif
+
+#endif

--- a/src/tests/tests.c
+++ b/src/tests/tests.c
@@ -4,8 +4,10 @@
 #include <stdbool.h>
 #include <stdio.h>
 #if !defined(SYSTEM_BASE_WINDOWS)
-#include <sys/ioctl.h>
+  #include <sys/ioctl.h>
 #endif
+
+#include "../actrie.h"
 
 #ifndef UWUFETCH_VERSION
   #define UWUFETCH_VERSION "unkown" // needs to be changed by the build script
@@ -69,6 +71,698 @@ struct test tests[] = {
     STRUCT_TEST(get_terminal_size),
 };
 
+struct test_context_t {
+  struct vector_string_t found_occurances;
+  struct vector_uint32_t start_indexes_in_original_text;
+};
+
+void test_run_text_callback(void* context, const char* found_word, size_t word_length, size_t start_index_in_original_text) {
+  struct test_context_t* ctx = (struct test_context_t*)context;
+  vector_uint32_t_emplace_back1(&(ctx->start_indexes_in_original_text), (uint32_t)start_index_in_original_text);
+  vector_string_t_emplace_back2(&(ctx->start_indexes_in_original_text), found_word, word_length);
+}
+
+static bool run_test(
+    const char* (*patterns_with_replacements)[2],
+    size_t patterns_size,
+    const char read_text[],
+    const char* expected_occurances[],
+    const uint32_t expected_occurances_pos[],
+    size_t expected_occurances_size,
+    char replacing_text[],
+    size_t replacing_text_size,
+    const char expected_replacing_text[],
+    bool replace_all_occurances) {
+  struct actrie_t t;
+  actrie_t_ctor(&t);
+
+  struct test_context_t context;
+  vector_string_t_ctor(&context.found_occurances);
+  vector_uint32_t_ctor(&context.start_indexes_in_original_text);
+
+  actrie_t_reserve_patterns(&t, patterns_size);
+  for (size_t i = 0; i < patterns_size; i++) {
+    actrie_t_add_pattern(&t, patterns_with_replacements[i][0], patterns_with_replacements[i][1]);
+  }
+
+  bool result = false;
+  for (size_t i = 0; i < patterns_size; i++) {
+    if (!actrie_t_contains_pattern(&t, patterns_with_replacements[i][0])) {
+      goto cleanup;
+    }
+  }
+
+  if (actrie_t_patterns_size(&t) != patterns_size) {
+    goto cleanup;
+  }
+
+  actrie_t_compute_links(&t);
+  if (!actrie_t_is_ready(&t)) {
+    goto cleanup;
+  }
+
+  vector_string_t_reserve(&context.found_occurances, expected_occurances_size);
+  vector_uint32_t_reserve(&context.start_indexes_in_original_text, expected_occurances_size);
+  actrie_t_run_text(&t, read_text, (void*)&context, &test_run_text_callback);
+
+  if (context.found_occurances.size != context.start_indexes_in_original_text.size || context.found_occurances.size != expected_occurances_size) {
+    goto cleanup;
+  }
+
+  for (size_t i = 0; i < expected_occurances_size; i++) {
+    if (strcmp(expected_occurances[i], context.found_occurances.data[i].c_str) != 0 || expected_occurances_pos[i] != context.start_indexes_in_original_text.data[i]) {
+      goto cleanup;
+    }
+  }
+
+  replacing_text[replacing_text_size] = '\0';
+  if (replace_all_occurances) {
+    actrie_t_replace_all_occurances(&t, replacing_text);
+  } else {
+    actrie_t_replace_first_occurance(&t, replacing_text);
+  }
+
+  result = (strcmp(replacing_text, expected_replacing_text) == 0);
+
+cleanup:
+  vector_uint32_t_dtor(&context.start_indexes_in_original_text);
+  vector_string_t_dtor(&context.found_occurances);
+  actrie_t_dtor(&t);
+
+  return result;
+}
+
+bool test0_short() {
+  const char* patterns_with_replacements[][2] = {
+      {"ab", "cd"},
+      {"ba", "dc"},
+      {"aa", "cc"},
+      {"bb", "dd"},
+      {"fasb", "xfasbx"},
+  };
+  const size_t patterns_size = sizeof(patterns_with_replacements) / sizeof(patterns_with_replacements[0]);
+
+  const char read_text[]            = "abbabbababbbabfabfbfafafbsfabsfasbabbbababbabbaa";
+  const char* expected_occurances[] = {
+      "ab", "bb", "ba", "ab", "bb",
+      "ba", "ab", "ba", "ab", "bb",
+      "bb", "ba", "ab", "ab", "ab",
+      "fasb", "ba", "ab", "bb", "bb",
+      "ba", "ab", "ba", "ab", "bb",
+      "ba", "ab", "bb", "ba", "aa"};
+
+  const uint32_t expected_occurances_pos[] = {
+      0, 1, 2, 3, 4, 5,
+      6, 7, 8, 9, 10, 11,
+      12, 15, 27, 30, 33, 34,
+      35, 36, 37, 38, 39, 40,
+      41, 42, 43, 44, 45, 46};
+
+  const size_t expected_occurances_size = sizeof(expected_occurances) / sizeof(expected_occurances[0]);
+  static_assert(expected_occurances_size == sizeof(expected_occurances_pos) / sizeof(expected_occurances_pos[0]));
+
+  char replacing_text[]                = "ababcdacafaasbfasbabcc  ";
+  const char expected_replacing_text[] = "cdcdcdacafccsbxfasbxcdcc";
+  const size_t replacing_text_size     = 22; // after 'c'
+
+  return run_test(patterns_with_replacements,
+                  patterns_size,
+                  read_text,
+                  expected_occurances,
+                  expected_occurances_pos,
+                  expected_occurances_size,
+                  replacing_text,
+                  replacing_text_size,
+                  expected_replacing_text,
+                  true);
+}
+
+bool test1_short() {
+  const char* patterns_with_replacements[][2] = {
+      {"ab", "cd"},
+      {"ba", "dc"},
+      {"aa", "cc"},
+      {"bb", "dd"},
+      {"xfasbx", "fasb"}};
+  const size_t patterns_size = sizeof(patterns_with_replacements) / sizeof(patterns_with_replacements[0]);
+
+  const char read_text[]            = "abbabbababbbabxfasbxfbfafafbsfabsxfasbxabbbababbabbaa";
+  const char* expected_occurances[] = {
+      "ab", "bb", "ba", "ab", "bb",
+      "ba", "ab", "ba", "ab", "bb",
+      "bb", "ba", "ab", "xfasbx", "ab",
+      "xfasbx", "ab", "bb", "bb", "ba",
+      "ab", "ba", "ab", "bb", "ba",
+      "ab", "bb", "ba", "aa"};
+
+  const uint32_t expected_occurances_pos[] = {
+      0, 1, 2, 3, 4,
+      5, 6, 7, 8, 9,
+      10, 11, 12, 14, 30,
+      33, 39, 40, 41, 42,
+      43, 44, 45, 46, 47,
+      48, 49, 50, 51};
+
+  const size_t expected_occurances_size = sizeof(expected_occurances) / sizeof(expected_occurances[0]);
+  static_assert(expected_occurances_size == sizeof(expected_occurances_pos) / sizeof(expected_occurances_pos[0]));
+
+  char replacing_text[]                = "ababcdacafaasbxfasbxabcc";
+  const char expected_replacing_text[] = "cdcdcdacafccsbfasbcdcc";
+  const size_t replacing_text_size     = 24; // 'c'
+
+  return run_test(patterns_with_replacements,
+                  patterns_size,
+                  read_text,
+                  expected_occurances,
+                  expected_occurances_pos,
+                  expected_occurances_size,
+                  replacing_text,
+                  replacing_text_size,
+                  expected_replacing_text,
+                  true);
+}
+
+bool test2_short() {
+  const char* patterns_with_replacements[][2] = {
+      {"LM", "0000"},
+      {"GHI", "111111"},
+      {"BCD", "2222222"},
+      {"nop", "3333"},
+      {"jk", "44444"}};
+  const size_t patterns_size = sizeof(patterns_with_replacements) / sizeof(patterns_with_replacements[0]);
+
+  const char read_text[]                   = "acbcdbgfgacdbsgdegfdjkjdaskjdegcbegfasdcdg";
+  const char* expected_occurances[]        = {"bcd", "jk"};
+  const uint32_t expected_occurances_pos[] = {2, 20};
+
+  const size_t expected_occurances_size = sizeof(expected_occurances) / sizeof(expected_occurances[0]);
+  static_assert(expected_occurances_size == sizeof(expected_occurances_pos) / sizeof(expected_occurances_pos[0]));
+
+  char replacing_text[]                = "ABCDEFGHIJKLMNOP             ";
+  const char expected_replacing_text[] = "A2222222EF1111114444400003333";
+  const size_t replacing_text_size     = 16; // after 'P'
+
+  return run_test(patterns_with_replacements,
+                  patterns_size,
+                  read_text,
+                  expected_occurances,
+                  expected_occurances_pos,
+                  expected_occurances_size,
+                  replacing_text,
+                  replacing_text_size,
+                  expected_replacing_text,
+                  true);
+}
+
+bool test3_short() {
+  const char* patterns_with_replacements[][2] = {
+      {"AB", "111111111111111111111111"},
+      {"CD", "cd"},
+      {"EF", "ef"},
+      {"JK", "jk"},
+      {"NO", "no"}};
+  const size_t patterns_size = sizeof(patterns_with_replacements) / sizeof(patterns_with_replacements[0]);
+
+  const char read_text[]            = "bacbcbdbabcbdbbfggasdasdncnononocabcbdbcbdcdbacbcbdbcbfgbcdabbcdgdcnpnpnnonoojkcajcjdk";
+  const char* expected_occurances[] = {
+      "ab", "no", "no", "no", "ab", "cd",
+      "cd", "ab", "cd", "no", "no", "jk"};
+
+  const uint32_t expected_occurances_pos[] = {
+      8, 26, 28, 30, 33, 42,
+      57, 59, 62, 72, 74, 77};
+
+  const size_t expected_occurances_size = sizeof(expected_occurances) / sizeof(expected_occurances[0]);
+  static_assert(expected_occurances_size == sizeof(expected_occurances_pos) / sizeof(expected_occurances_pos[0]));
+
+  char replacing_text[]                = "ABCDEFGHIJKLMNOP                      ";
+  const char expected_replacing_text[] = "111111111111111111111111cdefGHIjkLMnoP";
+  const size_t replacing_text_size     = 16; // after 'P'
+  return run_test(patterns_with_replacements,
+                  patterns_size,
+                  read_text,
+                  expected_occurances,
+                  expected_occurances_pos,
+                  expected_occurances_size,
+                  replacing_text,
+                  replacing_text_size,
+                  expected_replacing_text,
+                  true);
+}
+
+bool test4_short() {
+  const char* patterns_with_replacements[][2] = {
+      {"AB", "ab"},
+      {"CD", "cd"},
+      {"EF", "ef"},
+      {"JK", "jk"},
+      {"NO", "111111111111111111111111"}};
+  const size_t patterns_size = sizeof(patterns_with_replacements) / sizeof(patterns_with_replacements[0]);
+
+  const char read_text[]            = "bacbcbdbabcbdbbfggasdasdncnononocabcbdbcbdcdbacbcbdbcbfgbcdabbcdgdcnpnpnnonoojkcajcjdjk";
+  const char* expected_occurances[] = {
+      "ab", "no", "no", "no", "ab",
+      "cd", "cd", "ab", "cd", "no",
+      "no", "jk", "jk"};
+
+  const uint32_t expected_occurances_pos[] = {
+      8, 26, 28, 30, 33,
+      42, 57, 59, 62, 72,
+      74, 77, 85};
+
+  const size_t expected_occurances_size = sizeof(expected_occurances) / sizeof(expected_occurances[0]);
+  static_assert(expected_occurances_size == sizeof(expected_occurances_pos) / sizeof(expected_occurances_pos[0]));
+
+  char replacing_text[]                = "ABCDEFGHIJKLMNOP                      ";
+  const char expected_replacing_text[] = "abcdefGHIjkLM111111111111111111111111P";
+  const size_t replacing_text_size     = 16; // after 'P'
+  return run_test(patterns_with_replacements,
+                  patterns_size,
+                  read_text,
+                  expected_occurances,
+                  expected_occurances_pos,
+                  expected_occurances_size,
+                  replacing_text,
+                  replacing_text_size,
+                  expected_replacing_text,
+                  true);
+}
+
+bool test5_short() {
+  const char* patterns_with_replacements[][2] = {
+      {"AB", "ab"},
+      {"CD", "cd"},
+      {"EF", "111111111111111111111111"},
+      {"JK", "jk"},
+      {"NO", "no"}};
+  const size_t patterns_size = sizeof(patterns_with_replacements) / sizeof(patterns_with_replacements[0]);
+
+  const char read_text[]            = "bacbcbdbABcbdbbfggasdasdncnononocabcbdbcbdcdbacbcbdbcbfgbcdabbcdgdcnpnpnnonoojkcajcjdJK";
+  const char* expected_occurances[] = {
+      "AB", "no", "no", "no", "ab",
+      "cd", "cd", "ab", "cd", "no",
+      "no", "jk", "JK"};
+
+  const uint32_t expected_occurances_pos[] = {
+      8, 26, 28, 30, 33,
+      42, 57, 59, 62, 72,
+      74, 77, 85};
+
+  const size_t expected_occurances_size = sizeof(expected_occurances) / sizeof(expected_occurances[0]);
+  static_assert(expected_occurances_size == sizeof(expected_occurances_pos) / sizeof(expected_occurances_pos[0]));
+
+  char replacing_text[]                = "ABCDEFGHIJKLMNOP                      ";
+  const char expected_replacing_text[] = "abcd111111111111111111111111GHIjkLMnoP";
+  const size_t replacing_text_size     = 16; // after 'P'
+  return run_test(patterns_with_replacements,
+                  patterns_size,
+                  read_text,
+                  expected_occurances,
+                  expected_occurances_pos,
+                  expected_occurances_size,
+                  replacing_text,
+                  replacing_text_size,
+                  expected_replacing_text,
+                  true);
+}
+
+bool test6_short() {
+  const char* patterns_with_replacements[][2] = {
+      {"kernel", "Kewnel"},
+      {"linux", "Linuwu"},
+      {"debian", "Debinyan"},
+      {"ubuntu", "Uwuntu"},
+      {"windows", "WinyandOwOws"}};
+  const size_t patterns_size = sizeof(patterns_with_replacements) / sizeof(patterns_with_replacements[0]);
+
+  const char read_text[]                   = "linux kernel; debian os; ubuntu os; windows os";
+  const char* expected_occurances[]        = {"linux", "kernel", "debian", "ubuntu", "windows"};
+  const uint32_t expected_occurances_pos[] = {0, 6, 14, 25, 36};
+
+  const size_t expected_occurances_size = sizeof(expected_occurances) / sizeof(expected_occurances[0]);
+  static_assert(expected_occurances_size == sizeof(expected_occurances_pos) / sizeof(expected_occurances_pos[0]));
+
+  char replacing_text[]                = "linux kernel; debian os; ubuntu os; windows os        ";
+  const char expected_replacing_text[] = "Linuwu Kewnel; Debinyan os; Uwuntu os; WinyandOwOws os";
+  const size_t replacing_text_size     = 46; // after 's'
+  return run_test(patterns_with_replacements,
+                  patterns_size,
+                  read_text,
+                  expected_occurances,
+                  expected_occurances_pos,
+                  expected_occurances_size,
+                  replacing_text,
+                  replacing_text_size,
+                  expected_replacing_text,
+                  true);
+}
+
+bool test7_long() {
+  const char* patterns_with_replacements[][2] = {
+      {"brew-cask", "bwew-cawsk"},
+      {"brew-cellar", "bwew-cewwaw"},
+      {"emerge", "emewge"},
+      {"flatpak", "fwatpakkies"},
+      {"pacman", "pacnyan"},
+      {"port", "powt"},
+      {"rpm", "rawrpm"},
+      {"snap", "snyap"},
+      {"zypper", "zyppew"},
+
+      {"lenovo", "LenOwO"},
+      {"cpu", "CPUwU"},
+      {"core", "Cowe"},
+      {"gpu", "GPUwU"},
+      {"graphics", "Gwaphics"},
+      {"corporation", "COwOpowation"},
+      {"nvidia", "NyaVIDIA"},
+      {"mobile", "Mwobile"},
+      {"intel", "Inteww"},
+      {"radeon", "Radenyan"},
+      {"geforce", "GeFOwOce"},
+      {"raspberry", "Nyasberry"},
+      {"broadcom", "Bwoadcom"},
+      {"motorola", "MotOwOwa"},
+      {"proliant", "ProLinyant"},
+      {"poweredge", "POwOwEdge"},
+      {"apple", "Nyapple"},
+      {"electronic", "ElectrOwOnic"},
+      {"processor", "Pwocessow"},
+      {"microsoft", "MicOwOsoft"},
+      {"ryzen", "Wyzen"},
+      {"advanced", "Adwanced"},
+      {"micro", "Micwo"},
+      {"devices", "Dewices"},
+      {"inc.", "Nyanc."},
+      {"lucienne", "Lucienyan"},
+      {"tuxedo", "TUWUXEDO"},
+      {"aura", "Uwura"},
+
+      {"linux", "linuwu"},
+      {"alpine", "Nyalpine"},
+      {"amogos", "AmogOwOS"},
+      {"android", "Nyandroid"},
+      {"arch", "Nyarch Linuwu"},
+
+      {"arcolinux", "ArcOwO Linuwu"},
+
+      {"artix", "Nyartix Linuwu"},
+      {"debian", "Debinyan"},
+
+      {"devuan", "Devunyan"},
+
+      {"deepin", "Dewepyn"},
+      {"endeavouros", "endeavOwO"},
+      {"fedora", "Fedowa"},
+      {"femboyos", "FemboyOWOS"},
+      {"gentoo", "GentOwO"},
+      {"gnu", "gnUwU"},
+      {"guix", "gnUwU gUwUix"},
+      {"linuxmint", "LinUWU Miwint"},
+      {"manjaro", "Myanjawo"},
+      {"manjaro-arm", "Myanjawo AWM"},
+      {"neon", "KDE NeOwOn"},
+      {"nixos", "nixOwOs"},
+      {"opensuse-leap", "OwOpenSUSE Leap"},
+      {"opensuse-tumbleweed", "OwOpenSUSE Tumbleweed"},
+      {"pop", "PopOwOS"},
+      {"raspbian", "RaspNyan"},
+      {"rocky", "Wocky Linuwu"},
+      {"slackware", "Swackwawe"},
+      {"solus", "sOwOlus"},
+      {"ubuntu", "Uwuntu"},
+      {"void", "OwOid"},
+      {"xerolinux", "xuwulinux"},
+
+      // BSD
+      {"freebsd", "FweeBSD"},
+      {"openbsd", "OwOpenBSD"},
+
+      // Apple family
+      {"macos", "macOwOS"},
+      {"ios", "iOwOS"},
+
+      // Windows
+      {"windows", "WinyandOwOws"},
+  };
+  const size_t patterns_size = sizeof(patterns_with_replacements) / sizeof(patterns_with_replacements[0]);
+
+  const char read_text[]            = "windows freebsd rocky; neon linux; fedora; pop os; solus; amogos; void; ryzen and intel processor";
+  const char* expected_occurances[] = {
+      "windows", "freebsd", "rocky", "neon", "linux", "fedora", "pop",
+      "solus", "amogos", "void", "ryzen", "intel", "processor"};
+
+  const uint32_t expected_occurances_pos[] = {
+      0,
+      8,
+      16,
+      23,
+      28,
+      35,
+      43,
+      51,
+      58,
+      66,
+      72,
+      82,
+      88,
+  };
+
+  const size_t expected_occurances_size = sizeof(expected_occurances) / sizeof(expected_occurances[0]);
+  static_assert(expected_occurances_size == sizeof(expected_occurances_pos) / sizeof(expected_occurances_pos[0]));
+
+  char replacing_text[]                = "windows freebsd rocky; neon linux; fedora; pop os; solus; amogos; void; ryzen and intel processor                             ";
+  const char expected_replacing_text[] = "WinyandOwOws FweeBSD Wocky Linuwu; KDE NeOwOn linuwu; Fedowa; PopOwOS os; sOwOlus; AmogOwOS; OwOid; Wyzen and Inteww Pwocessow";
+  const size_t replacing_text_size     = 97; // after 'r'
+
+  return run_test(patterns_with_replacements,
+                  patterns_size,
+                  read_text,
+                  expected_occurances,
+                  expected_occurances_pos,
+                  expected_occurances_size,
+                  replacing_text,
+                  replacing_text_size,
+                  expected_replacing_text,
+                  true);
+}
+
+bool test8_long() {
+  const char* patterns_with_replacements[][2] = {
+      {"brew-cask", "bwew-cawsk"},
+      {"brew-cellar", "bwew-cewwaw"},
+      {"emerge", "emewge"},
+      {"flatpak", "fwatpakkies"},
+      {"pacman", "pacnyan"},
+      {"port", "powt"},
+      {"rpm", "rawrpm"},
+      {"snap", "snyap"},
+      {"zypper", "zyppew"},
+
+      {"lenovo", "LenOwO"},
+      {"cpu", "CPUwU"},
+      {"core", "Cowe"},
+      {"gpu", "GPUwU"},
+      {"graphics", "Gwaphics"},
+      {"corporation", "COwOpowation"},
+      {"nvidia", "NyaVIDIA"},
+      {"mobile", "Mwobile"},
+      {"intel", "Inteww"},
+      {"radeon", "Radenyan"},
+      {"geforce", "GeFOwOce"},
+      {"raspberry", "Nyasberry"},
+      {"broadcom", "Bwoadcom"},
+      {"motorola", "MotOwOwa"},
+      {"proliant", "ProLinyant"},
+      {"poweredge", "POwOwEdge"},
+      {"apple", "Nyapple"},
+      {"electronic", "ElectrOwOnic"},
+      {"processor", "Pwocessow"},
+      {"microsoft", "MicOwOsoft"},
+      {"ryzen", "Wyzen"},
+      {"advanced", "Adwanced"},
+      {"micro", "Micwo"},
+      {"devices", "Dewices"},
+      {"inc.", "Nyanc."},
+      {"lucienne", "Lucienyan"},
+      {"tuxedo", "TUWUXEDO"},
+      {"aura", "Uwura"},
+
+      {"linux", "linuwu"},
+      {"alpine", "Nyalpine"},
+      {"amogos", "AmogOwOS"},
+      {"android", "Nyandroid"},
+      {"arch", "Nyarch Linuwu"},
+
+      {"arcolinux", "ArcOwO Linuwu"},
+
+      {"artix", "Nyartix Linuwu"},
+      {"debian", "Debinyan"},
+
+      {"devuan", "Devunyan"},
+
+      {"deepin", "Dewepyn"},
+      {"endeavouros", "endeavOwO"},
+      {"fedora", "Fedowa"},
+      {"femboyos", "FemboyOWOS"},
+      {"gentoo", "GentOwO"},
+      {"gnu", "gnUwU"},
+      {"guix", "gnUwU gUwUix"},
+      {"linuxmint", "LinUWU Miwint"},
+      {"manjaro", "Myanjawo"},
+      {"manjaro-arm", "Myanjawo AWM"},
+      {"neon", "KDE NeOwOn"},
+      {"nixos", "nixOwOs"},
+      {"opensuse-leap", "OwOpenSUSE Leap"},
+      {"opensuse-tumbleweed", "OwOpenSUSE Tumbleweed"},
+      {"pop", "PopOwOS"},
+      {"raspbian", "RaspNyan"},
+      {"rocky", "Wocky Linuwu"},
+      {"slackware", "Swackwawe"},
+      {"solus", "sOwOlus"},
+      {"ubuntu", "Uwuntu"},
+      {"void", "OwOid"},
+      {"xerolinux", "xuwulinux"},
+
+      // BSD
+      {"freebsd", "FweeBSD"},
+      {"openbsd", "OwOpenBSD"},
+
+      // Apple family
+      {"macos", "macOwOS"},
+      {"ios", "iOwOS"},
+
+      // Windows
+      {"windows", "WinyandOwOws"},
+  };
+  const size_t patterns_size = sizeof(patterns_with_replacements) / sizeof(patterns_with_replacements[0]);
+
+  char replacing_text[]                = "windows FREEBSD ROCKy; NEON linux; FEDORA; pop os; solus; amogos; Void; ryzEN and Intel PROCessor                             ";
+  const char expected_replacing_text[] = "WinyandOwOws FweeBSD Wocky Linuwu; KDE NeOwOn linuwu; Fedowa; PopOwOS os; sOwOlus; AmogOwOS; OwOid; Wyzen and Inteww Pwocessow";
+  const size_t replacing_text_size     = 97; // after 'r'
+
+  const char read_text[]            = "windows FREEBSD ROCKy; NEON linux; FEDORA; pop os; solus; amogos; Void; ryzEN and Intel PROCessor";
+  const char* expected_occurances[] = {
+      "windows", "FREEBSD", "ROCKy", "NEON", "linux", "FEDORA", "pop",
+      "solus", "amogos", "Void", "ryzEN", "Intel", "PROCessor"};
+
+  const uint32_t expected_occurances_pos[] = {
+      0,
+      8,
+      16,
+      23,
+      28,
+      35,
+      43,
+      51,
+      58,
+      66,
+      72,
+      82,
+      88,
+  };
+
+  const size_t expected_occurances_size = sizeof(expected_occurances) / sizeof(expected_occurances[0]);
+  static_assert(expected_occurances_size == sizeof(expected_occurances_pos) / sizeof(expected_occurances_pos[0]));
+
+  return run_test(patterns_with_replacements,
+                  patterns_size,
+                  read_text,
+                  expected_occurances,
+                  expected_occurances_pos,
+                  expected_occurances_size,
+                  replacing_text,
+                  replacing_text_size,
+                  expected_replacing_text,
+                  true);
+}
+
+bool test9_short() {
+  const char* patterns_with_replacements[][2] = {
+      {"abc", "def"},
+      {"ghi", "jkz"},
+  };
+  const size_t patterns_size = sizeof(patterns_with_replacements) / sizeof(patterns_with_replacements[0]);
+
+  const char read_text[]                   = "cabcbacbbcabacbacbbacbachggiuichaihacihaichacbacbbcachachgighighighbcbaa";
+  const char* expected_occurances[]        = {"abc", "ghi", "ghi"};
+  const uint32_t expected_occurances_pos[] = {1, 59, 62};
+
+  const size_t expected_occurances_size = sizeof(expected_occurances) / sizeof(expected_occurances[0]);
+  static_assert(expected_occurances_size == sizeof(expected_occurances_pos) / sizeof(expected_occurances_pos[0]));
+
+  char replacing_text[]                = "Abghciashjdhwdjahwdjhabdabanabwc";
+  const char expected_replacing_text[] = "Abghciashjdhwdjahwdjhabdabanabwc";
+  const size_t replacing_text_size     = 32; // after 'c'
+
+  return run_test(patterns_with_replacements,
+                  patterns_size,
+                  read_text,
+                  expected_occurances,
+                  expected_occurances_pos,
+                  expected_occurances_size,
+                  replacing_text,
+                  replacing_text_size,
+                  expected_replacing_text,
+                  true);
+}
+
+bool test10_short() {
+  const char* patterns_with_replacements[][2] = {
+      {"abc", "def"},
+      {"ghi", "jkz"},
+  };
+  const size_t patterns_size = sizeof(patterns_with_replacements) / sizeof(patterns_with_replacements[0]);
+
+  const char read_text[]                   = "cAbcbacbbcabacbacbbacbachggiuichaihacihaichacbacbbcachachgighiGhighbcbaa";
+  const char* expected_occurances[]        = {"Abc", "ghi", "Ghi"};
+  const uint32_t expected_occurances_pos[] = {1, 59, 62};
+
+  const size_t expected_occurances_size = sizeof(expected_occurances) / sizeof(expected_occurances[0]);
+  static_assert(expected_occurances_size == sizeof(expected_occurances_pos) / sizeof(expected_occurances_pos[0]));
+
+  char replacing_text[]                = "Qghiabcabcghiabc";
+  const char expected_replacing_text[] = "Qjkzabcabcghiabc";
+  const size_t replacing_text_size     = 16; // after 'c'
+
+  return run_test(patterns_with_replacements,
+                  patterns_size,
+                  read_text,
+                  expected_occurances,
+                  expected_occurances_pos,
+                  expected_occurances_size,
+                  replacing_text,
+                  replacing_text_size,
+                  expected_replacing_text,
+                  false);
+}
+
+static void test_actrie(int* passed_tests, int* failed_tests) {
+  bool (*test_functions[])() = {
+      &test0_short,
+      &test1_short,
+      &test2_short,
+      &test3_short,
+      &test4_short,
+      &test5_short,
+      &test6_short,
+      &test7_long,
+      &test8_long,
+      &test9_short,
+      &test10_short,
+  };
+
+  for (size_t i = 0; i < sizeof(test_functions) / sizeof(test_functions[0]); i++) {
+    if (test_functions[i]()) {
+      LOG_I("AC trie test %zu <g>PASSED</>", (i + 1));
+      (*passed_tests)++;
+    } else {
+      LOG_E("AC trie test %zu <r>FAILED</>", (i + 1));
+      (*failed_tests)++;
+    }
+  }
+}
+
 int main(int argc, char** argv) {
   SET_LOG_LEVEL(LEVEL_MAX, "TESTS");
   if (argc > 1) {
@@ -92,6 +786,7 @@ int main(int argc, char** argv) {
       failed_tests++;
     }
   }
+  test_actrie(&passed_tests, &failed_tests);
   LOG_I("\n%d tests <g>passed</>, %d <r>failed</>", passed_tests, failed_tests);
   libfetch_cleanup();
   return 0;

--- a/src/tests/tests.c
+++ b/src/tests/tests.c
@@ -79,7 +79,7 @@ struct test_context_t {
 void test_run_text_callback(void* context, const char* found_word, size_t word_length, size_t start_index_in_original_text) {
   struct test_context_t* ctx = (struct test_context_t*)context;
   vector_uint32_t_emplace_back1(&(ctx->start_indexes_in_original_text), (uint32_t)start_index_in_original_text);
-  vector_string_t_emplace_back2(&(ctx->start_indexes_in_original_text), found_word, word_length);
+  vector_string_t_emplace_back2(&(ctx->found_occurances), found_word, word_length);
 }
 
 static bool run_test(
@@ -130,7 +130,9 @@ static bool run_test(
   }
 
   for (size_t i = 0; i < expected_occurances_size; i++) {
-    if (strcmp(expected_occurances[i], context.found_occurances.data[i].c_str) != 0 || expected_occurances_pos[i] != context.start_indexes_in_original_text.data[i]) {
+    size_t expected_length = strlen(expected_occurances[i]);
+    size_t found_lenght    = context.found_occurances.data[i].size;
+    if (expected_length != found_lenght || strncmp(expected_occurances[i], context.found_occurances.data[i].c_str, expected_length) != 0 || expected_occurances_pos[i] != context.start_indexes_in_original_text.data[i]) {
       goto cleanup;
     }
   }
@@ -179,7 +181,7 @@ bool test0_short() {
       41, 42, 43, 44, 45, 46};
 
   const size_t expected_occurances_size = sizeof(expected_occurances) / sizeof(expected_occurances[0]);
-  static_assert(expected_occurances_size == sizeof(expected_occurances_pos) / sizeof(expected_occurances_pos[0]));
+  static_assert(sizeof(expected_occurances) / sizeof(expected_occurances[0]) == sizeof(expected_occurances_pos) / sizeof(expected_occurances_pos[0]));
 
   char replacing_text[]                = "ababcdacafaasbfasbabcc  ";
   const char expected_replacing_text[] = "cdcdcdacafccsbxfasbxcdcc";
@@ -224,7 +226,7 @@ bool test1_short() {
       48, 49, 50, 51};
 
   const size_t expected_occurances_size = sizeof(expected_occurances) / sizeof(expected_occurances[0]);
-  static_assert(expected_occurances_size == sizeof(expected_occurances_pos) / sizeof(expected_occurances_pos[0]));
+  static_assert(sizeof(expected_occurances) / sizeof(expected_occurances[0]) == sizeof(expected_occurances_pos) / sizeof(expected_occurances_pos[0]));
 
   char replacing_text[]                = "ababcdacafaasbxfasbxabcc";
   const char expected_replacing_text[] = "cdcdcdacafccsbfasbcdcc";
@@ -256,7 +258,7 @@ bool test2_short() {
   const uint32_t expected_occurances_pos[] = {2, 20};
 
   const size_t expected_occurances_size = sizeof(expected_occurances) / sizeof(expected_occurances[0]);
-  static_assert(expected_occurances_size == sizeof(expected_occurances_pos) / sizeof(expected_occurances_pos[0]));
+  static_assert(sizeof(expected_occurances) / sizeof(expected_occurances[0]) == sizeof(expected_occurances_pos) / sizeof(expected_occurances_pos[0]));
 
   char replacing_text[]                = "ABCDEFGHIJKLMNOP             ";
   const char expected_replacing_text[] = "A2222222EF1111114444400003333";
@@ -293,7 +295,7 @@ bool test3_short() {
       57, 59, 62, 72, 74, 77};
 
   const size_t expected_occurances_size = sizeof(expected_occurances) / sizeof(expected_occurances[0]);
-  static_assert(expected_occurances_size == sizeof(expected_occurances_pos) / sizeof(expected_occurances_pos[0]));
+  static_assert(sizeof(expected_occurances) / sizeof(expected_occurances[0]) == sizeof(expected_occurances_pos) / sizeof(expected_occurances_pos[0]));
 
   char replacing_text[]                = "ABCDEFGHIJKLMNOP                      ";
   const char expected_replacing_text[] = "111111111111111111111111cdefGHIjkLMnoP";
@@ -331,7 +333,7 @@ bool test4_short() {
       74, 77, 85};
 
   const size_t expected_occurances_size = sizeof(expected_occurances) / sizeof(expected_occurances[0]);
-  static_assert(expected_occurances_size == sizeof(expected_occurances_pos) / sizeof(expected_occurances_pos[0]));
+  static_assert(sizeof(expected_occurances) / sizeof(expected_occurances[0]) == sizeof(expected_occurances_pos) / sizeof(expected_occurances_pos[0]));
 
   char replacing_text[]                = "ABCDEFGHIJKLMNOP                      ";
   const char expected_replacing_text[] = "abcdefGHIjkLM111111111111111111111111P";
@@ -369,7 +371,7 @@ bool test5_short() {
       74, 77, 85};
 
   const size_t expected_occurances_size = sizeof(expected_occurances) / sizeof(expected_occurances[0]);
-  static_assert(expected_occurances_size == sizeof(expected_occurances_pos) / sizeof(expected_occurances_pos[0]));
+  static_assert(sizeof(expected_occurances) / sizeof(expected_occurances[0]) == sizeof(expected_occurances_pos) / sizeof(expected_occurances_pos[0]));
 
   char replacing_text[]                = "ABCDEFGHIJKLMNOP                      ";
   const char expected_replacing_text[] = "abcd111111111111111111111111GHIjkLMnoP";
@@ -400,7 +402,7 @@ bool test6_short() {
   const uint32_t expected_occurances_pos[] = {0, 6, 14, 25, 36};
 
   const size_t expected_occurances_size = sizeof(expected_occurances) / sizeof(expected_occurances[0]);
-  static_assert(expected_occurances_size == sizeof(expected_occurances_pos) / sizeof(expected_occurances_pos[0]));
+  static_assert(sizeof(expected_occurances) / sizeof(expected_occurances[0]) == sizeof(expected_occurances_pos) / sizeof(expected_occurances_pos[0]));
 
   char replacing_text[]                = "linux kernel; debian os; ubuntu os; windows os        ";
   const char expected_replacing_text[] = "Linuwu Kewnel; Debinyan os; Uwuntu os; WinyandOwOws os";
@@ -529,7 +531,7 @@ bool test7_long() {
   };
 
   const size_t expected_occurances_size = sizeof(expected_occurances) / sizeof(expected_occurances[0]);
-  static_assert(expected_occurances_size == sizeof(expected_occurances_pos) / sizeof(expected_occurances_pos[0]));
+  static_assert(sizeof(expected_occurances) / sizeof(expected_occurances[0]) == sizeof(expected_occurances_pos) / sizeof(expected_occurances_pos[0]));
 
   char replacing_text[]                = "windows freebsd rocky; neon linux; fedora; pop os; solus; amogos; void; ryzen and intel processor                             ";
   const char expected_replacing_text[] = "WinyandOwOws FweeBSD Wocky Linuwu; KDE NeOwOn linuwu; Fedowa; PopOwOS os; sOwOlus; AmogOwOS; OwOid; Wyzen and Inteww Pwocessow";
@@ -663,7 +665,7 @@ bool test8_long() {
   };
 
   const size_t expected_occurances_size = sizeof(expected_occurances) / sizeof(expected_occurances[0]);
-  static_assert(expected_occurances_size == sizeof(expected_occurances_pos) / sizeof(expected_occurances_pos[0]));
+  static_assert(sizeof(expected_occurances) / sizeof(expected_occurances[0]) == sizeof(expected_occurances_pos) / sizeof(expected_occurances_pos[0]));
 
   return run_test(patterns_with_replacements,
                   patterns_size,
@@ -689,7 +691,7 @@ bool test9_short() {
   const uint32_t expected_occurances_pos[] = {1, 59, 62};
 
   const size_t expected_occurances_size = sizeof(expected_occurances) / sizeof(expected_occurances[0]);
-  static_assert(expected_occurances_size == sizeof(expected_occurances_pos) / sizeof(expected_occurances_pos[0]));
+  static_assert(sizeof(expected_occurances) / sizeof(expected_occurances[0]) == sizeof(expected_occurances_pos) / sizeof(expected_occurances_pos[0]));
 
   char replacing_text[]                = "Abghciashjdhwdjahwdjhabdabanabwc";
   const char expected_replacing_text[] = "Abghciashjdhwdjahwdjhabdabanabwc";
@@ -719,7 +721,7 @@ bool test10_short() {
   const uint32_t expected_occurances_pos[] = {1, 59, 62};
 
   const size_t expected_occurances_size = sizeof(expected_occurances) / sizeof(expected_occurances[0]);
-  static_assert(expected_occurances_size == sizeof(expected_occurances_pos) / sizeof(expected_occurances_pos[0]));
+  static_assert(sizeof(expected_occurances) / sizeof(expected_occurances[0]) == sizeof(expected_occurances_pos) / sizeof(expected_occurances_pos[0]));
 
   char replacing_text[]                = "Qghiabcabcghiabc";
   const char expected_replacing_text[] = "Qjkzabcabcghiabc";

--- a/src/uwufetch.c
+++ b/src/uwufetch.c
@@ -19,6 +19,7 @@
 
 #define _GNU_SOURCE // for strcasestr
 
+#include "actrie.h"
 #include "fetch.h"
 #ifdef __APPLE__
   #include <TargetConditionals.h> // for checking iOS
@@ -290,8 +291,8 @@ int print_image(struct info* user_info) {
 void replace(char* original, const char* search, const char* replacer) {
   char* ch;
   char buffer[1024];
-  ssize_t offset = 0;
-  ssize_t search_len = (ssize_t)strlen(search);
+  ssize_t offset       = 0;
+  ssize_t search_len   = (ssize_t)strlen(search);
   ssize_t replacer_len = (ssize_t)strlen(replacer);
   while ((ch = strstr(original + offset, search))) {
     strncpy(buffer, original, (size_t)(ch - original));
@@ -311,7 +312,7 @@ void replace_ignorecase(char* original, const char* search, const char* replacer
 #ifdef _WIN32
   #define strcasestr(o, s) strstr(o, s)
 #endif
-  ssize_t search_len = (ssize_t)strlen(search);
+  ssize_t search_len   = (ssize_t)strlen(search);
   ssize_t replacer_len = (ssize_t)strlen(replacer);
   while ((ch = strcasestr(original + offset, search))) {
     strncpy(buffer, original, (size_t)(ch - original));
@@ -393,145 +394,141 @@ void uwu_name(struct info* user_info) {
 }
 
 // uwufies kernel name
-void uwu_kernel(char* kernel) {
-#define KERNEL_TO_UWU(str, original, uwufied) \
-  if (strcmp(str, original) == 0) sprintf(str, "%s", uwufied)
-
+void uwu_kernel(const struct actrie_t* replacer, char* kernel) {
   LOG_I("uwufing kernel");
-
-  char* temp_kernel = kernel;
-  char* token;
-  char splitted[16][128] = {0};
-
-  int count = 0;
-  while ((token = strsep(&temp_kernel, " "))) { // split kernel name
-    strcpy(splitted[count], token);
-    count++;
-  }
-  if (kernel) strcpy(kernel, "");
-  for (int i = 0; i < 16; i++) {
-    // replace kernel name with uwufied version
-    KERNEL_TO_UWU(splitted[i], "Linux", "Linuwu");
-    else KERNEL_TO_UWU(splitted[i], "linux", "linuwu");
-    else KERNEL_TO_UWU(splitted[i], "alpine", "Nyalpine");
-    else KERNEL_TO_UWU(splitted[i], "amogos", "AmogOwOS");
-    else KERNEL_TO_UWU(splitted[i], "android", "Nyandroid");
-    else KERNEL_TO_UWU(splitted[i], "arch", "Nyarch Linuwu");
-    else KERNEL_TO_UWU(splitted[i], "artix", "Nyartix Linuwu");
-    else KERNEL_TO_UWU(splitted[i], "debian", "Debinyan");
-    else KERNEL_TO_UWU(splitted[i], "deepin", "Dewepyn");
-    else KERNEL_TO_UWU(splitted[i], "endeavouros", "endeavOwO");
-    else KERNEL_TO_UWU(splitted[i], "EndeavourOS", "endeavOwO");
-    else KERNEL_TO_UWU(splitted[i], "fedora", "Fedowa");
-    else KERNEL_TO_UWU(splitted[i], "femboyos", "FemboyOWOS");
-    else KERNEL_TO_UWU(splitted[i], "gentoo", "GentOwO");
-    else KERNEL_TO_UWU(splitted[i], "gnu", "gnUwU");
-    else KERNEL_TO_UWU(splitted[i], "guix", "gnUwU gUwUix");
-    else KERNEL_TO_UWU(splitted[i], "linuxmint", "LinUWU Miwint");
-    else KERNEL_TO_UWU(splitted[i], "manjaro", "Myanjawo");
-    else KERNEL_TO_UWU(splitted[i], "manjaro-arm", "Myanjawo AWM");
-    else KERNEL_TO_UWU(splitted[i], "neon", "KDE NeOwOn");
-    else KERNEL_TO_UWU(splitted[i], "nixos", "nixOwOs");
-    else KERNEL_TO_UWU(splitted[i], "opensuse-leap", "OwOpenSUSE Leap");
-    else KERNEL_TO_UWU(splitted[i], "opensuse-tumbleweed", "OwOpenSUSE Tumbleweed");
-    else KERNEL_TO_UWU(splitted[i], "pop", "PopOwOS");
-    else KERNEL_TO_UWU(splitted[i], "raspbian", "RaspNyan");
-    else KERNEL_TO_UWU(splitted[i], "rocky", "Wocky Linuwu");
-    else KERNEL_TO_UWU(splitted[i], "slackware", "Swackwawe");
-    else KERNEL_TO_UWU(splitted[i], "solus", "sOwOlus");
-    else KERNEL_TO_UWU(splitted[i], "ubuntu", "Uwuntu");
-    else KERNEL_TO_UWU(splitted[i], "void", "OwOid");
-    else KERNEL_TO_UWU(splitted[i], "xerolinux", "xuwulinux");
-
-    // BSD
-    else KERNEL_TO_UWU(splitted[i], "freebsd", "FweeBSD");
-    else KERNEL_TO_UWU(splitted[i], "openbsd", "OwOpenBSD");
-
-    // Apple family
-    else KERNEL_TO_UWU(splitted[i], "macos", "macOwOS");
-    else KERNEL_TO_UWU(splitted[i], "ios", "iOwOS");
-
-    // Windows
-    else KERNEL_TO_UWU(splitted[i], "windows", "WinyandOwOws");
-
-    if (kernel) {
-      if (i != 0) strcat(kernel, " ");
-      strcat(kernel, splitted[i]);
-    }
-  }
-#undef KERNEL_TO_UWU
+  actrie_t_replace_all_occurances(replacer, kernel);
   LOG_V(kernel);
 }
 
 // uwufies hardware names
-void uwu_hw(char* hwname) {
+void uwu_hw(const struct actrie_t* replacer, char* hwname) {
   LOG_I("uwufing hardware")
-#define HW_TO_UWU(original, uwuified) replace_ignorecase(hwname, original, uwuified);
-  HW_TO_UWU("lenovo", "LenOwO")
-  HW_TO_UWU("cpu", "CPUwU");
-  HW_TO_UWU("core", "Cowe");
-  HW_TO_UWU("gpu", "GPUwU")
-  HW_TO_UWU("graphics", "Gwaphics")
-  HW_TO_UWU("corporation", "COwOpowation")
-  HW_TO_UWU("nvidia", "NyaVIDIA")
-  HW_TO_UWU("mobile", "Mwobile")
-  HW_TO_UWU("intel", "Inteww")
-  HW_TO_UWU("radeon", "Radenyan")
-  HW_TO_UWU("geforce", "GeFOwOce")
-  HW_TO_UWU("raspberry", "Nyasberry")
-  HW_TO_UWU("broadcom", "Bwoadcom")
-  HW_TO_UWU("motorola", "MotOwOwa")
-  HW_TO_UWU("proliant", "ProLinyant")
-  HW_TO_UWU("poweredge", "POwOwEdge")
-  HW_TO_UWU("apple", "Nyapple")
-  HW_TO_UWU("electronic", "ElectrOwOnic")
-  HW_TO_UWU("processor", "Pwocessow")
-  HW_TO_UWU("microsoft", "MicOwOsoft")
-  HW_TO_UWU("ryzen", "Wyzen")
-  HW_TO_UWU("advanced", "Adwanced")
-  HW_TO_UWU("micro", "Micwo")
-  HW_TO_UWU("devices", "Dewices")
-  HW_TO_UWU("inc.", "Nyanc.")
-  HW_TO_UWU("lucienne", "Lucienyan")
-  HW_TO_UWU("tuxedo", "TUWUXEDO")
-  HW_TO_UWU("aura", "Uwura")
-#undef HW_TO_UWU
+  actrie_t_replace_all_occurances(replacer, hwname);
 }
 
 // uwufies package manager names
-void uwu_pkgman(char* pkgman_name) {
-  LOG_I("uwufing package managers")
-#define PKGMAN_TO_UWU(original, uwuified) replace_ignorecase(pkgman_name, original, uwuified);
-  // these package managers do not have edits yet:
-  // apk, apt, guix, nix, pkg, xbps
-  PKGMAN_TO_UWU("brew-cask", "bwew-cawsk");
-  PKGMAN_TO_UWU("brew-cellar", "bwew-cewwaw");
-  PKGMAN_TO_UWU("emerge", "emewge");
-  PKGMAN_TO_UWU("flatpak", "fwatpakkies");
-  PKGMAN_TO_UWU("pacman", "pacnyan");
-  PKGMAN_TO_UWU("port", "powt");
-  PKGMAN_TO_UWU("rpm", "rawrpm");
-  PKGMAN_TO_UWU("snap", "snyap");
-  PKGMAN_TO_UWU("zypper", "zyppew");
-#undef PKGMAN_TO_UWU
+void uwu_pkgman(const struct actrie_t* replacer, char* pkgman_name) {
+  LOG_I("uwufing package managers");
+  actrie_t_replace_all_occurances(replacer, pkgman_name);
 }
 
 // uwufies everything
 void uwufy_all(struct info* user_info) {
-#define UWU_HW(x) \
-  if (x) uwu_hw(x)
+  struct actrie_t replacer;
+  actrie_t_ctor(&replacer);
+
+  const size_t PATTERNS_COUNT = 73;
+  // Not necessary but recommended
+  actrie_t_reserve_patterns(&replacer, PATTERNS_COUNT);
+
+  // these package managers do not have edits yet:
+  // apk, apt, guix, nix, pkg, xbps
+  actrie_t_add_pattern(&replacer, "brew-cask", "bwew-cawsk");
+  actrie_t_add_pattern(&replacer, "brew-cellar", "bwew-cewwaw");
+  actrie_t_add_pattern(&replacer, "emerge", "emewge");
+  actrie_t_add_pattern(&replacer, "flatpak", "fwatpakkies");
+  actrie_t_add_pattern(&replacer, "pacman", "pacnyan");
+  actrie_t_add_pattern(&replacer, "port", "powt");
+  actrie_t_add_pattern(&replacer, "rpm", "rawrpm");
+  actrie_t_add_pattern(&replacer, "snap", "snyap");
+  actrie_t_add_pattern(&replacer, "zypper", "zyppew");
+
+  actrie_t_add_pattern(&replacer, "lenovo", "LenOwO");
+  actrie_t_add_pattern(&replacer, "cpu", "CPUwU");
+  actrie_t_add_pattern(&replacer, "core", "Cowe");
+  actrie_t_add_pattern(&replacer, "gpu", "GPUwU");
+  actrie_t_add_pattern(&replacer, "graphics", "Gwaphics");
+  actrie_t_add_pattern(&replacer, "corporation", "COwOpowation");
+  actrie_t_add_pattern(&replacer, "nvidia", "NyaVIDIA");
+  actrie_t_add_pattern(&replacer, "mobile", "Mwobile");
+  actrie_t_add_pattern(&replacer, "intel", "Inteww");
+  actrie_t_add_pattern(&replacer, "radeon", "Radenyan");
+  actrie_t_add_pattern(&replacer, "geforce", "GeFOwOce");
+  actrie_t_add_pattern(&replacer, "raspberry", "Nyasberry");
+  actrie_t_add_pattern(&replacer, "broadcom", "Bwoadcom");
+  actrie_t_add_pattern(&replacer, "motorola", "MotOwOwa");
+  actrie_t_add_pattern(&replacer, "proliant", "ProLinyant");
+  actrie_t_add_pattern(&replacer, "poweredge", "POwOwEdge");
+  actrie_t_add_pattern(&replacer, "apple", "Nyapple");
+  actrie_t_add_pattern(&replacer, "electronic", "ElectrOwOnic");
+  actrie_t_add_pattern(&replacer, "processor", "Pwocessow");
+  actrie_t_add_pattern(&replacer, "microsoft", "MicOwOsoft");
+  actrie_t_add_pattern(&replacer, "ryzen", "Wyzen");
+  actrie_t_add_pattern(&replacer, "advanced", "Adwanced");
+  actrie_t_add_pattern(&replacer, "micro", "Micwo");
+  actrie_t_add_pattern(&replacer, "devices", "Dewices");
+  actrie_t_add_pattern(&replacer, "inc.", "Nyanc.");
+  actrie_t_add_pattern(&replacer, "lucienne", "Lucienyan");
+  actrie_t_add_pattern(&replacer, "tuxedo", "TUWUXEDO");
+  actrie_t_add_pattern(&replacer, "aura", "Uwura");
+
+  actrie_t_add_pattern(&replacer, "linux", "Linuwu");
+  actrie_t_add_pattern(&replacer, "alpine", "Nyalpine");
+  actrie_t_add_pattern(&replacer, "amogos", "AmogOwOS");
+  actrie_t_add_pattern(&replacer, "android", "Nyandroid");
+  actrie_t_add_pattern(&replacer, "arch", "Nyarch Linuwu");
+
+  actrie_t_add_pattern(&replacer, "arcolinux", "ArcOwO Linuwu");
+
+  actrie_t_add_pattern(&replacer, "artix", "Nyartix Linuwu");
+  actrie_t_add_pattern(&replacer, "debian", "Debinyan");
+
+  actrie_t_add_pattern(&replacer, "devuan", "Devunyan");
+
+  actrie_t_add_pattern(&replacer, "deepin", "Dewepyn");
+  actrie_t_add_pattern(&replacer, "endeavouros", "endeavOwO");
+  actrie_t_add_pattern(&replacer, "fedora", "Fedowa");
+  actrie_t_add_pattern(&replacer, "femboyos", "FemboyOWOS");
+  actrie_t_add_pattern(&replacer, "gentoo", "GentOwO");
+  actrie_t_add_pattern(&replacer, "gnu", "gnUwU");
+  actrie_t_add_pattern(&replacer, "guix", "gnUwU gUwUix");
+  actrie_t_add_pattern(&replacer, "linuxmint", "LinUWU Miwint");
+  actrie_t_add_pattern(&replacer, "manjaro", "Myanjawo");
+  actrie_t_add_pattern(&replacer, "manjaro-arm", "Myanjawo AWM");
+  actrie_t_add_pattern(&replacer, "neon", "KDE NeOwOn");
+  actrie_t_add_pattern(&replacer, "nixos", "nixOwOs");
+  actrie_t_add_pattern(&replacer, "opensuse-leap", "OwOpenSUSE Leap");
+  actrie_t_add_pattern(&replacer, "opensuse-tumbleweed", "OwOpenSUSE Tumbleweed");
+  actrie_t_add_pattern(&replacer, "pop", "PopOwOS");
+  actrie_t_add_pattern(&replacer, "raspbian", "RaspNyan");
+  actrie_t_add_pattern(&replacer, "rocky", "Wocky Linuwu");
+  actrie_t_add_pattern(&replacer, "slackware", "Swackwawe");
+  actrie_t_add_pattern(&replacer, "solus", "sOwOlus");
+  actrie_t_add_pattern(&replacer, "ubuntu", "Uwuntu");
+  actrie_t_add_pattern(&replacer, "void", "OwOid");
+  actrie_t_add_pattern(&replacer, "xerolinux", "xuwulinux");
+
+  // BSD
+  actrie_t_add_pattern(&replacer, "freebsd", "FweeBSD");
+  actrie_t_add_pattern(&replacer, "openbsd", "OwOpenBSD");
+
+  // Apple family
+  actrie_t_add_pattern(&replacer, "macos", "macOwOS");
+  actrie_t_add_pattern(&replacer, "ios", "iOwOS");
+
+  // Windows
+  actrie_t_add_pattern(&replacer, "windows", "WinyandOwOws");
+
   LOG_I("uwufing everything");
-  uwu_kernel(user_info->kernel);
+  uwu_kernel(&replacer, user_info->kernel);
   if (user_info->gpus)
     for (int i = 0; i < 256; i++)
-      UWU_HW(user_info->gpus[i]);
-  UWU_HW(user_info->cpu_model);
+      if (user_info->gpus[i])
+        uwu_hw(&replacer, user_info->gpus[i]);
+
+  if (user_info->cpu_model)
+    uwu_hw(&replacer, user_info->cpu_model);
   LOG_V(user_info->cpu_model);
-  UWU_HW(user_info->model);
+
+  if (user_info->model)
+    uwu_hw(&replacer, user_info->model);
   LOG_V(user_info->model);
-  if (user_info->packages) uwu_pkgman(user_info->packages);
+
+  if (user_info->packages)
+    uwu_pkgman(&replacer, user_info->packages);
   LOG_V(user_info->packages);
-#undef UWU_HW
+
+  actrie_t_dtor(&replacer);
 }
 
 // prints all the collected info and returns the number of printed lines

--- a/src/uwufetch.c
+++ b/src/uwufetch.c
@@ -341,56 +341,18 @@ char* strsep(char** stringp, const char* delim) {
 #endif
 
 // uwufies distro name
-void uwu_name(struct info* user_info) {
-  if (!user_info->os_name) return;
-#define STRING_TO_UWU(original, uwufied) \
-  if (strcmp(user_info->os_name, original) == 0) sprintf(user_info->os_name, "%s", uwufied)
-  // linux
-  STRING_TO_UWU("alpine", "Nyalpine");
-  else STRING_TO_UWU("amogos", "AmogOwOS");
-  else STRING_TO_UWU("android", "Nyandroid");
-  else STRING_TO_UWU("arch", "Nyarch Linuwu");
-  else STRING_TO_UWU("arcolinux", "ArcOwO Linuwu");
-  else STRING_TO_UWU("artix", "Nyartix Linuwu");
-  else STRING_TO_UWU("debian", "Debinyan");
-  else STRING_TO_UWU("devuan", "Devunyan");
-  else STRING_TO_UWU("deepin", "Dewepyn");
-  else STRING_TO_UWU("endeavouros", "endeavOwO");
-  else STRING_TO_UWU("EndeavourOS", "endeavOwO");
-  else STRING_TO_UWU("fedora", "Fedowa");
-  else STRING_TO_UWU("femboyos", "FemboyOWOS");
-  else STRING_TO_UWU("gentoo", "GentOwO");
-  else STRING_TO_UWU("gnu", "gnUwU");
-  else STRING_TO_UWU("guix", "gnUwU gUwUix");
-  else STRING_TO_UWU("linuxmint", "LinUWU Miwint");
-  else STRING_TO_UWU("manjaro", "Myanjawo");
-  else STRING_TO_UWU("manjaro-arm", "Myanjawo AWM");
-  else STRING_TO_UWU("neon", "KDE NeOwOn");
-  else STRING_TO_UWU("nixos", "nixOwOs");
-  else STRING_TO_UWU("opensuse-leap", "OwOpenSUSE Leap");
-  else STRING_TO_UWU("opensuse-tumbleweed", "OwOpenSUSE Tumbleweed");
-  else STRING_TO_UWU("pop", "PopOwOS");
-  else STRING_TO_UWU("raspbian", "RaspNyan");
-  else STRING_TO_UWU("rocky", "Wocky Linuwu");
-  else STRING_TO_UWU("slackware", "Swackwawe");
-  else STRING_TO_UWU("solus", "sOwOlus");
-  else STRING_TO_UWU("ubuntu", "Uwuntu");
-  else STRING_TO_UWU("void", "OwOid");
-  else STRING_TO_UWU("xerolinux", "xuwulinux");
+void uwu_name(const struct actrie_t* replacer, struct info* user_info) {
+  char* os_name = user_info->os_name;
+  if (os_name == NULL) {
+    return;
+  }
 
-  // BSD
-  else STRING_TO_UWU("freebsd", "FweeBSD");
-  else STRING_TO_UWU("openbsd", "OwOpenBSD");
+  if (*os_name == '\0') {
+    sprintf(os_name, "%s", "unknown");
+    return;
+  }
 
-  // Apple family
-  else STRING_TO_UWU("macos", "macOwOS");
-  else STRING_TO_UWU("ios", "iOwOS");
-
-  // Windows
-  else STRING_TO_UWU("windows", "WinyandOwOws");
-
-  else sprintf(user_info->os_name, "%s", "unknown");
-#undef STRING_TO_UWU
+  actrie_t_replace_all_occurances(replacer, os_name);
 }
 
 // uwufies kernel name
@@ -530,6 +492,8 @@ void uwufy_all(struct info* user_info) {
     uwu_pkgman(&replacer, user_info->packages);
   LOG_V(user_info->packages);
 
+  uwu_name(&replacer, user_info);
+
   actrie_t_dtor(&replacer);
 }
 
@@ -548,7 +512,7 @@ int print_info(struct configuration* config_flags, struct info* user_info) {
   // print collected info - from host to cpu info
   if (config_flags->user)
     responsively_printf(print_buf, "%s%s%s%s@%s", MOVE_CURSOR, NORMAL, BOLD, user_info->user_name, user_info->host_name);
-  uwu_name(user_info);
+
   if (config_flags->os)
     responsively_printf(print_buf, "%s%s%sOWOS     %s%s", MOVE_CURSOR, NORMAL, BOLD, NORMAL, user_info->os_name);
   if (config_flags->model)

--- a/src/uwufetch.c
+++ b/src/uwufetch.c
@@ -509,6 +509,8 @@ void uwufy_all(struct info* user_info) {
   // Windows
   actrie_t_add_pattern(&replacer, "windows", "WinyandOwOws");
 
+  actrie_t_compute_links(&replacer);
+
   LOG_I("uwufing everything");
   uwu_kernel(&replacer, user_info->kernel);
   if (user_info->gpus)


### PR DESCRIPTION
## Describe your changes
Added a replacer class that is based on the AC trie data structure.

It replaces all occurrences of given patterns (case insensetive) in the given text in O(new_length) where new_length is a length of the text after replacement. Before all replacements (uwufying kernel name, hardware names, etc) were done in
O(patterns_count * pattern_length * new_length) on average, so this data structure speeds up replacement of the substrings.

Also now all patterns and replacements for them are added in one function `void uwufy_all(struct info*)`, while before they all were used separately in the different functions. As a result it will be easier to add new patterns in the future. (all you need to add a new pattern is write `actrie_t_add_pattern(&replacer, pattern, pattern_replacement);` )

To test this data structure 11 tests were added to the `/src/tests/tests.c`
New file "actrie.h" is formatted with clang-format and changes are tested with `make`, `make debug` and `make tests` on Ubuntu based OS

Example of how replacer works can be found in added test functions, for example, in `bool test8_long()`:
(all this replacements are done in O(new_length) without splitting the original string)
![image](https://github.com/TheDarkBug/uwufetch/assets/92759021/0600ec5a-98cb-4d80-bec0-b39a35548e67)

Settings of this class can be modified in the beginning of the `actrie.h` header file:
![image](https://github.com/TheDarkBug/uwufetch/assets/92759021/3262657d-0282-4d05-aa70-7a9071db87c0)
