### PR TITLE
use rpm for openSUSE systems (remove zypper package count)

### DIFF
--- a/fetch.c
+++ b/fetch.c
@@ -381,8 +381,7 @@ void* get_pkg(void* argp) { // this is just a function that returns the total of
       {PKGPATH "brew", "find $(brew --cellar 2>/dev/stdout) -maxdepth 1 -type d 2> /dev/null | wc -l | awk '{print $1}'", "(brew-cellar)"},
       {PKGPATH "brew", "find $(brew --caskroom 2>/dev/stdout) -maxdepth 1 -type d 2> /dev/null | wc -l | awk '{print $1}'", "(brew-cask)"},
       {PKGPATH "rpm", "rpm -qa --last 2> /dev/null | wc -l", "(rpm)"},
-      {PKGPATH "xbps-query", "xbps-query -l 2> /dev/null | wc -l", "(xbps)"},
-      {PKGPATH "zypper", "zypper -q se --installed-only 2> /dev/null | wc -l", "(zypper)"}};
+      {PKGPATH "xbps-query", "xbps-query -l 2> /dev/null | wc -l", "(xbps)"}};
   #endif
 #else
   struct package_manager pkgmans[] = {{"/usr/local/bin/brew", "find $(brew --cellar 2>/dev/stdout) -maxdepth 1 -type d 2> /dev/null | wc -l | awk '{print $1}' > /tmp/uwufetch_brew_tmp", "(brew-cellar)"},

--- a/uwufetch.c
+++ b/uwufetch.c
@@ -441,7 +441,6 @@ void uwu_pkgman(char* pkgman_name) {
   PKGMAN_TO_UWU("flatpak", "fwatpakkies");
   PKGMAN_TO_UWU("pacman", "pacnyan");
   PKGMAN_TO_UWU("port", "powt");
-  PKGMAN_TO_UWU("rpm", "rawrpm");
   PKGMAN_TO_UWU("snap", "snyap");
   PKGMAN_TO_UWU("zypper", "zyppew");
 #undef PKGMAN_TO_UWU

--- a/uwufetch.c
+++ b/uwufetch.c
@@ -442,7 +442,6 @@ void uwu_pkgman(char* pkgman_name) {
   PKGMAN_TO_UWU("pacman", "pacnyan");
   PKGMAN_TO_UWU("port", "powt");
   PKGMAN_TO_UWU("snap", "snyap");
-  PKGMAN_TO_UWU("zypper", "zyppew");
 #undef PKGMAN_TO_UWU
 }
 


### PR DESCRIPTION
On openSUSE systems uwufetch shows both RPM and Zypper package counts, it looks like this:
`PKGS     6092: 3040 (rawrpm), 3052 (zyppew)`.
Since RPM is more universal and works well for zypper, it can be removed from source code.
Both neofetch and fastfetch uses RPM package count for openSUSE systems.